### PR TITLE
Fixed typo of closing acute sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ Sorting the results
 
 Add relationship
 
-`http://prettus.local/users?with=groups
+`http://prettus.local/users?with=groups`
 
 
 


### PR DESCRIPTION
Closing acute sign was missing in line 644