### PR TITLE
Fix allowedCache method

### DIFF
--- a/src/Prettus/Repository/Traits/CacheableRepository.php
+++ b/src/Prettus/Repository/Traits/CacheableRepository.php
@@ -87,7 +87,7 @@ trait CacheableRepository {
         $cacheExcept  = isset($this->cacheExcept)   ? $this->cacheExcept  : config('repository.cache.allowed.except',null);
 
         if ( is_array($cacheOnly) ) {
-            return isset($cacheOnly[$method]);
+            return in_array($method, $cacheOnly);
         }
 
         if ( is_array($cacheExcept) ) {


### PR DESCRIPTION
If `repository.cache.allowed.only` is set, or some repositories have `cacheOnly` attributes, `allowedCache` method always returns `false`. So I patched the code, and it worked well.