### PR TITLE
Update Versions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     "source":"https://github.com/andersao/l5-repository"
   },
   "require": {
-    "illuminate/http": "~5.0|~5.1|~5.2",
-    "illuminate/config": "~5.0|~5.1|~5.2",
-    "illuminate/support": "~5.0|~5.1|~5.2",
-    "illuminate/database": "~5.0|~5.1|~5.2",
-    "illuminate/pagination": "~5.0|~5.1|~5.2",
-    "illuminate/console": "~5.0|~5.1|~5.2",
-    "illuminate/filesystem": "~5.0|~5.1|~5.2"
+    "illuminate/http": "~5.0",
+    "illuminate/config": "~5.0",
+    "illuminate/support": "~5.0",
+    "illuminate/database": "~5.0",
+    "illuminate/pagination": "~5.0",
+    "illuminate/console": "~5.0",
+    "illuminate/filesystem": "~5.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
When you do `~5.0` it means, you're supporting `5.1` & `5.2` automatically.  It translates to: `>=5.0.0,<6.0.0`. So all the minor/patches are covered.

If however, you want to limit it, then you should be doing: `5.0.*|5.1.*|5.2.*` <-- This will limit the package to be used within these 3 versions and their patches only.

But it's better to do what i just did in this PR, So it'll also support dev version of  `5.3` or other in development easily.