### PR TITLE
fix generate wrong namespace

### DIFF
--- a/src/Prettus/Repository/Generators/Generator.php
+++ b/src/Prettus/Repository/Generators/Generator.php
@@ -221,7 +221,7 @@ abstract class Generator
         if ($rootNamespace == false)
             return null;
 
-        return rtrim($rootNamespace . '\\'. implode($segments, '\\'), '\\');
+        return strtr(rtrim($rootNamespace . '\\'. implode($segments, '\\'), '\\'), '/', '\\');
     }
 
     /**

--- a/src/Prettus/Repository/Generators/Generator.php
+++ b/src/Prettus/Repository/Generators/Generator.php
@@ -185,7 +185,7 @@ abstract class Generator
             case ('transformers' === $class):
                 $path = config('repository.generator.paths.transformers', 'Transformers');
                 break;
-            default;
+            default:
                 $path = '';
         }
 
@@ -205,13 +205,25 @@ abstract class Generator
      */
     public function getNamespace()
     {
+        return 'namespace ' . $this->getNamespaceName() . ';';
+    }
+
+    /**
+     * Returns namespace basename.
+     *
+     * @return string
+     */
+    public function getNamespaceName()
+    {
         $segments = $this->getSegments();
         array_pop($segments);
         $rootNamespace = $this->getRootNamespace();
         if ($rootNamespace == false)
             return null;
-        return 'namespace ' . rtrim($rootNamespace . implode($segments, '\\'), '\\') . ';';
+
+        return rtrim($rootNamespace . '\\'. implode($segments, '\\'), '\\');
     }
+
     /**
      * Setup some hook.
      *

--- a/src/Prettus/Repository/Generators/PresenterGenerator.php
+++ b/src/Prettus/Repository/Generators/PresenterGenerator.php
@@ -52,8 +52,10 @@ class PresenterGenerator extends Generator
      */
     public function getReplacements()
     {
+        $transformerGenerator = new TransformerGenerator(['name' => $this->name]);
+
         return array_merge(parent::getReplacements(), [
-            'appnamespace' => $this->getAppNamespace()
+            'transformer_namespace' => $transformerGenerator->getNamespaceName()
         ]);
     }
 

--- a/src/Prettus/Repository/Generators/RepositoryEloquentGenerator.php
+++ b/src/Prettus/Repository/Generators/RepositoryEloquentGenerator.php
@@ -64,9 +64,12 @@ class RepositoryEloquentGenerator extends Generator
      */
     public function getReplacements()
     {
+        $repository = parent::getRootNamespace() . parent::getConfigGeneratorClassPath('interfaces') . '\\' . $this->getName() . 'Repository;';
+        $repository = strtr($repository, '/', '\\');
+
         return array_merge(parent::getReplacements(), [
             'fillable' => $this->getFillable(),
-            'repository' => parent::getRootNamespace() . parent::getConfigGeneratorClassPath('interfaces') . '\\' . $this->getName() . 'Repository;',
+            'repository' => $repository,
             'model'    => isset($this->options['model']) ? $this->options['model'] : ''
         ]);
     }

--- a/src/Prettus/Repository/Generators/Stubs/presenter/presenter.stub
+++ b/src/Prettus/Repository/Generators/Stubs/presenter/presenter.stub
@@ -2,7 +2,7 @@
 
 $NAMESPACE$
 
-use $APPNAMESPACE$Transformers\$CLASS$Transformer;
+use $TRANSFORMER_NAMESPACE$\$CLASS$Transformer;
 use Prettus\Repository\Presenter\FractalPresenter;
 
 /**

--- a/src/Prettus/Repository/Generators/TransformerGenerator.php
+++ b/src/Prettus/Repository/Generators/TransformerGenerator.php
@@ -62,9 +62,10 @@ class TransformerGenerator extends Generator
      */
     public function getReplacements()
     {
-        $modelGenerator = new ModelGenerator();
+        $modelGenerator = new ModelGenerator(['name' => $this->name]);
+
         return array_merge(parent::getReplacements(),[
-            'model_namespace' => $modelGenerator->getRootNamespace()
+            'model_namespace' => $modelGenerator->getNamespaceName()
         ]);
     }
 }


### PR DESCRIPTION
When generate an entity such as "Blog/Film" wit will generate a wrong namespace.
This is a fix.