### PR TITLE
casts data before validate

### DIFF
--- a/src/Prettus/Repository/Eloquent/BaseRepository.php
+++ b/src/Prettus/Repository/Eloquent/BaseRepository.php
@@ -383,6 +383,13 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
     public function create(array $attributes)
     {
         if ( !is_null($this->validator) ) {
+            // we should pass data that has been casts by the model
+            // to make sure data type are same because validator may need to use
+            // this data to compare with data that fetch from database.
+            $attributes = $this->model->newInstance()
+                ->forceFill($attributes)
+                ->toArray();
+
             $this->validator->with($attributes)
                 ->passesOrFail( ValidatorInterface::RULE_CREATE );
         }
@@ -409,6 +416,13 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
         $this->applyScope();
 
         if ( !is_null($this->validator) ) {
+            // we should pass data that has been casts by the model
+            // to make sure data type are same because validator may need to use
+            // this data to compare with data that fetch from database.
+            $attributes = $this->model->newInstance()
+                ->forceFill($attributes)
+                ->toArray();
+
             $this->validator->with($attributes)
                 ->setId($id)
                 ->passesOrFail( ValidatorInterface::RULE_UPDATE );
@@ -612,7 +626,7 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
             } elseif ( $result instanceof Presentable ) {
                 $result = $result->setPresenter($this->presenter);
             }
-    
+
             if( !$this->skipPresenter){
                 return $this->presenter->present($result);
             }


### PR DESCRIPTION
We should pass data that has been casts by the model to make sure data type are same
Because validator may need to use this data to compare with data that fetch from database.