### PR TITLE
Replace use of undefined function logger() with Facade access

### DIFF
--- a/src/Prettus/Repository/Listeners/CleanCacheRepository.php
+++ b/src/Prettus/Repository/Listeners/CleanCacheRepository.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\Log;
 use Prettus\Repository\Contracts\RepositoryInterface;
 use Prettus\Repository\Events\RepositoryEventBase;
 use Prettus\Repository\Helpers\CacheKeys;
@@ -68,7 +69,7 @@ class CleanCacheRepository {
                 }
             }
         } catch (\Exception $e) {
-            logger()->error($e->getMessage());
+            Log::error($e->getMessage());
         }
     }
 


### PR DESCRIPTION
This PR replaces the use of the `logger()` function in [1] by facade access.
Solves issuse #124 

[1] https://github.com/andersao/l5-repository/blob/master/src/Prettus/Repository/Listeners/CleanCacheRepository.php#L71