### PR TITLE
Outdent a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You want to know a little more about the Repository pattern? [Read this great ar
 Execute the following command to get the latest version of the package:
 
 ```terminal
-	composer require prettus/l5-repository
+composer require prettus/l5-repository
 ```
 
 ### Laravel


### PR DESCRIPTION
Removed space before command. Not sure why it was there but can be trouble with copying.