### PR TITLE
Add pagination querystring perPage parameter

### DIFF
--- a/src/Prettus/Repository/Eloquent/BaseRepository.php
+++ b/src/Prettus/Repository/Eloquent/BaseRepository.php
@@ -308,8 +308,9 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
     {
         $this->applyCriteria();
         $this->applyScope();
-        $limit = is_null($limit) ? config('repository.pagination.limit', 15) : $limit;
+        $limit = request()->get('perPage', is_null($limit) ? config('repository.pagination.limit', 15) : $limit);
         $results = $this->model->{$method}($limit, $columns);
+        $results->appends(request()->query());
         $this->resetModel();
         return $this->parserResult($results);
     }


### PR DESCRIPTION
Add querystring parameter "perPage" to allow set limit via url and appends others querystrings to next/prev url to use with RequestCriteria

    http://prettus.local/users?perPage=20&page=2&filter=name;email;city

    {
    "next_page_url": "http://prettus.local/users?perPage=20&filter=name;email;city&page=3",
    "prev_page_url": "http://prettus.local/users?perPage=20&filter=name;email;city&page=1",
    }