### PR TITLE
Added generator for RESTfull controller and repository service provider

### DIFF
--- a/src/Prettus/Repository/Generators/BindingsGenerator.php
+++ b/src/Prettus/Repository/Generators/BindingsGenerator.php
@@ -1,0 +1,133 @@
+<?php
+namespace Prettus\Repository\Generators;
+
+/**
+ * Class BindingsGenerator
+ * @package Prettus\Repository\Generators
+ */
+class BindingsGenerator extends Generator
+{
+
+    /**
+     * Get stub name.
+     *
+     * @var string
+     */
+    protected $stub = 'bindings/bindings';
+
+    /**
+     * The placeholder for repository bindings
+     *
+     * @var string
+     */
+    public $bindPlaceholder = '//:end-bindings:';
+
+
+    public function run()
+    {
+
+
+        // Add entity repository binding to the repository service provider
+        $provider            = \File::get($this->getPath());
+        $repositoryInterface = '\\' . $this->getRepository() . "::class";
+        $repositoryEloquent  = '\\' . $this->getEloquentRepository() . "::class";
+        \File::put($this->getPath(), str_replace($this->bindPlaceholder,
+            "\$this->app->bind({$repositoryInterface}, $repositoryEloquent);" . PHP_EOL . '        ' . $this->bindPlaceholder,
+            $provider));
+    }
+
+
+    /**
+     * Get base path of destination file.
+     *
+     * @return string
+     */
+    public function getBasePath()
+    {
+        return config('repository.generator.basePath', app_path());
+    }
+
+
+    /**
+     * Get root namespace.
+     *
+     * @return string
+     */
+    public function getRootNamespace()
+    {
+        return parent::getRootNamespace() . parent::getConfigGeneratorClassPath($this->getPathConfigNode());
+    }
+
+
+    /**
+     * Get generator path config node.
+     *
+     * @return string
+     */
+    public function getPathConfigNode()
+    {
+        return 'provider';
+    }
+
+
+    /**
+     * Get destination path for generated file.
+     *
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->getBasePath() . '/Providers/' . parent::getConfigGeneratorClassPath($this->getPathConfigNode(),
+            true) . '.php';
+    }
+
+
+    /**
+     * Get array replacements.
+     *
+     * @return array
+     */
+    public function getReplacements()
+    {
+
+        return array_merge(parent::getReplacements(), [
+            'repository'  => $this->getRepository(),
+            'eloquent'    => $this->getEloquentRepository(),
+            'placeholder' => $this->bindPlaceholder,
+        ]);
+    }
+
+
+    /**
+     * Gets repository full class name
+     *
+     * @return string
+     */
+    public function getRepository()
+    {
+        $repositoryGenerator = new RepositoryEloquentGenerator([
+            'name' => $this->name,
+        ]);
+
+        $repository = $repositoryGenerator->getRootNamespace() . '\\' . $repositoryGenerator->getName();
+
+        return str_replace([ "\\", '/' ], '\\', $repository) . 'Repository';
+    }
+
+
+    /**
+     * Gets eloquent repository full class name
+     *
+     * @return string
+     */
+    public function getEloquentRepository()
+    {
+        $repositoryGenerator = new RepositoryEloquentGenerator([
+            'name' => $this->name,
+        ]);
+
+        $repository = $repositoryGenerator->getRootNamespace() . '\\' . $repositoryGenerator->getName();
+
+        return str_replace([ "\\", '/' ], '\\', $repository) . 'RepositoryEloquent';
+    }
+}

--- a/src/Prettus/Repository/Generators/Commands/BindingsCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/BindingsCommand.php
@@ -1,0 +1,95 @@
+<?php
+namespace Prettus\Repository\Generators\Commands;
+
+use File;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Prettus\Repository\Generators\BindingsGenerator;
+use Prettus\Repository\Generators\FileAlreadyExistsException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class BindingsCommand extends Command
+{
+
+    /**
+     * The name of command.
+     *
+     * @var string
+     */
+    protected $name = 'make:bindings';
+
+    /**
+     * The description of command.
+     *
+     * @var string
+     */
+    protected $description = 'Add repository bindings to service provider.';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Bindings';
+
+
+    /**
+     * Execute the command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        try {
+            $bindingGenerator = new BindingsGenerator([
+                'name'  => $this->argument('name'),
+                'force' => $this->option('force'),
+            ]);
+            // generate repository service provider
+            if ( ! file_exists($bindingGenerator->getPath())) {
+                $this->call('make:provider', [
+                    'name' => $bindingGenerator->getConfigGeneratorClassPath($bindingGenerator->getPathConfigNode()),
+                ]);
+                // placeholder to mark the place in file where to prepend repository bindings
+                $provider = File::get($bindingGenerator->getPath());
+                File::put($bindingGenerator->getPath(), vsprintf(str_replace('//', '%s', $provider), [
+                    '//',
+                    $bindingGenerator->bindPlaceholder
+                ]));
+                $bindingGenerator->run();
+            }
+            $this->info($this->type . ' created successfully.');
+        } catch (FileAlreadyExistsException $e) {
+            $this->error($this->type . ' already exists!');
+
+            return false;
+        }
+    }
+
+
+    /**
+     * The array of command arguments.
+     *
+     * @return array
+     */
+    public function getArguments()
+    {
+        return [
+            [ 'name', InputArgument::REQUIRED, 'The name of model for which the controller is being generated.', null ],
+        ];
+    }
+
+
+    /**
+     * The array of command options.
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return [
+            [ 'force', 'f', InputOption::VALUE_NONE, 'Force the creation if file already exists.', null ],
+        ];
+    }
+}

--- a/src/Prettus/Repository/Generators/Commands/ControllerCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/ControllerCommand.php
@@ -1,0 +1,81 @@
+<?php
+namespace Prettus\Repository\Generators\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Prettus\Repository\Generators\ControllerGenerator;
+use Prettus\Repository\Generators\FileAlreadyExistsException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class ControllerCommand extends Command
+{
+
+    /**
+     * The name of command.
+     *
+     * @var string
+     */
+    protected $name = 'make:resource';
+
+    /**
+     * The description of command.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new controller.';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Controller';
+
+
+    /**
+     * Execute the command.
+     *
+     * @return void
+     */
+    public function fire()
+    {
+        try {
+            (new ControllerGenerator([
+                'name'  => $this->argument('name'),
+                'force' => $this->option('force'),
+            ]))->run();
+            $this->info($this->type . ' created successfully.');
+        } catch (FileAlreadyExistsException $e) {
+            $this->error($this->type . ' already exists!');
+
+            return false;
+        }
+    }
+
+
+    /**
+     * The array of command arguments.
+     *
+     * @return array
+     */
+    public function getArguments()
+    {
+        return [
+            [ 'name', InputArgument::REQUIRED, 'The name of model for which the controller is being generated.', null ],
+        ];
+    }
+
+
+    /**
+     * The array of command options.
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return [
+            [ 'force', 'f', InputOption::VALUE_NONE, 'Force the creation if file already exists.', null ],
+        ];
+    }
+}

--- a/src/Prettus/Repository/Generators/Commands/EntityCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/EntityCommand.php
@@ -57,6 +57,23 @@ class EntityCommand extends Command
             ]);
         }
 
+        if ($this->confirm('Would you like to create a Controller? [y|N]')) {
+
+            // Generate create request for controller
+            $this->call('make:request', [
+                'name' => $this->argument('name') . 'CreateRequest'
+            ]);
+            // Generate update request for controller
+            $this->call('make:request', [
+                'name' => $this->argument('name') . 'UpdateRequest'
+            ]);
+            // Generate a controller resource
+            $this->call('make:resource', [
+                'name' => $this->argument('name'),
+                '--force'     => $this->option('force')
+            ]);
+        }
+
         $this->call('make:repository', [
             'name'        => $this->argument('name'),
             '--fillable'  => $this->option('fillable'),

--- a/src/Prettus/Repository/Generators/Commands/EntityCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/EntityCommand.php
@@ -69,8 +69,8 @@ class EntityCommand extends Command
             ]);
             // Generate a controller resource
             $this->call('make:resource', [
-                'name' => $this->argument('name'),
-                '--force'     => $this->option('force')
+                'name'    => $this->argument('name'),
+                '--force' => $this->option('force')
             ]);
         }
 
@@ -79,6 +79,11 @@ class EntityCommand extends Command
             '--fillable'  => $this->option('fillable'),
             '--rules'     => $this->option('rules'),
             '--validator' => $validator,
+            '--force'     => $this->option('force')
+        ]);
+
+        $this->call('make:bindings', [
+            'name'        => $this->argument('name'),
             '--force'     => $this->option('force')
         ]);
     }

--- a/src/Prettus/Repository/Generators/ControllerGenerator.php
+++ b/src/Prettus/Repository/Generators/ControllerGenerator.php
@@ -1,0 +1,151 @@
+<?php
+namespace Prettus\Repository\Generators;
+
+use Prettus\Repository\Generators\Migrations\RulesParser;
+use Prettus\Repository\Generators\Migrations\SchemaParser;
+
+/**
+ * Class ControllerGenerator
+ * @package Prettus\Repository\Generators
+ */
+class ControllerGenerator extends Generator
+{
+
+    /**
+     * Get stub name.
+     *
+     * @var string
+     */
+    protected $stub = 'controller/controller';
+
+
+    /**
+     * Get base path of destination file.
+     *
+     * @return string
+     */
+    public function getBasePath()
+    {
+        return config('repository.generator.basePath', app_path());
+    }
+
+
+    /**
+     * Get root namespace.
+     *
+     * @return string
+     */
+    public function getRootNamespace()
+    {
+        return parent::getRootNamespace() . parent::getConfigGeneratorClassPath($this->getPathConfigNode());
+    }
+
+
+    /**
+     * Get generator path config node.
+     *
+     * @return string
+     */
+    public function getPathConfigNode()
+    {
+        return 'controllers';
+    }
+
+
+    /**
+     * Get destination path for generated file.
+     *
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->getBasePath() . '/' . parent::getConfigGeneratorClassPath($this->getPathConfigNode(),
+            true) . '/' . $this->getControllerName() . 'Controller.php';
+    }
+
+
+    /**
+     * Get array replacements.
+     *
+     * @return array
+     */
+    public function getReplacements()
+    {
+
+        return array_merge(parent::getReplacements(), [
+            'controller' => $this->getControllerName(),
+            'plural'     => $this->getPluralName(),
+            'singular'   => $this->getSingularName(),
+            'validator' => $this->getValidator(),
+            'repository'  => $this->getRepository(),
+        ]);
+    }
+
+
+    /**
+     * Gets controller name based on model
+     *
+     * @return string
+     */
+    public function getControllerName()
+    {
+
+        return ucfirst($this->getPluralName());
+    }
+
+
+    /**
+     * Gets plural name based on model
+     *
+     * @return string
+     */
+    public function getPluralName()
+    {
+
+        return str_plural(lcfirst(ucwords($this->getClass())));
+    }
+
+    /**
+     * Gets singular name based on model
+     *
+     * @return string
+     */
+    public function getSingularName()
+    {
+        return str_singular(lcfirst(ucwords($this->getClass())));
+    }
+
+
+    /**
+     * Gets validator full class name
+     *
+     * @return string
+     */
+    public function getValidator()
+    {
+        $validatorGenerator = new ValidatorGenerator([
+            'name' => $this->name,
+        ]);
+
+        $validator = $validatorGenerator->getRootNamespace() . '\\' . $validatorGenerator->getName();
+
+        return 'use ' . str_replace([ "\\", '/' ], '\\', $validator) . 'Validator;';
+    }
+
+
+    /**
+     * Gets repository full class name
+     *
+     * @return string
+     */
+    public function getRepository()
+    {
+        $repositoryGenerator = new RepositoryEloquentGenerator([
+            'name' => $this->name,
+        ]);
+
+        $repository = $repositoryGenerator->getRootNamespace() . '\\' . $repositoryGenerator->getName();
+
+        return 'use ' . str_replace([ "\\", '/' ], '\\', $repository) . 'Repository;';
+    }
+}

--- a/src/Prettus/Repository/Generators/Generator.php
+++ b/src/Prettus/Repository/Generators/Generator.php
@@ -202,6 +202,9 @@ abstract class Generator
             case ( 'controllers' === $class ):
                 $path = config('repository.generator.paths.controllers', 'Http\Controllers');
                 break;
+            case ( 'provider' === $class ):
+                $path = config('repository.generator.paths.provider', 'RepositoryServiceProvider');
+                break;
             default:
                 $path = '';
         }

--- a/src/Prettus/Repository/Generators/Generator.php
+++ b/src/Prettus/Repository/Generators/Generator.php
@@ -199,6 +199,9 @@ abstract class Generator
             case ( 'validators' === $class ):
                 $path = config('repository.generator.paths.validators', 'Validators');
                 break;
+            case ( 'controllers' === $class ):
+                $path = config('repository.generator.paths.controllers', 'Http\Controllers');
+                break;
             default:
                 $path = '';
         }

--- a/src/Prettus/Repository/Generators/Stubs/bindings/bindings.stub
+++ b/src/Prettus/Repository/Generators/Stubs/bindings/bindings.stub
@@ -1,0 +1,3 @@
+
+ 		$this->app->bind($REPOSITORY$, $ELOQUENT$);
+ 		$PLACEHOLDER$

--- a/src/Prettus/Repository/Generators/Stubs/controller/controller.stub
+++ b/src/Prettus/Repository/Generators/Stubs/controller/controller.stub
@@ -5,7 +5,8 @@ $NAMESPACE$
 use Illuminate\Http\Request;
 
 use App\Http\Requests;
-use \Prettus\Validator\Exceptions\ValidatorException;
+use Prettus\Validator\Contracts\ValidatorInterface;
+use Prettus\Validator\Exceptions\ValidatorException;
 use App\Http\Requests\$CLASS$CreateRequest;
 use App\Http\Requests\$CLASS$UpdateRequest;
 $REPOSITORY$

--- a/src/Prettus/Repository/Generators/Stubs/controller/controller.stub
+++ b/src/Prettus/Repository/Generators/Stubs/controller/controller.stub
@@ -1,0 +1,212 @@
+<?php
+
+$NAMESPACE$
+
+use Illuminate\Http\Request;
+
+use App\Http\Requests;
+use \Prettus\Validator\Exceptions\ValidatorException;
+use App\Http\Requests\$CLASS$CreateRequest;
+use App\Http\Requests\$CLASS$UpdateRequest;
+$REPOSITORY$
+$VALIDATOR$
+
+
+class $CONTROLLER$Controller extends Controller
+{
+
+    /**
+     * @var $CLASS$Repository
+     */
+    protected $repository;
+
+    /**
+     * @var $CLASS$Validator
+     */
+    protected $validator;
+
+
+    public function __construct($CLASS$Repository $repository, $CLASS$Validator $validator)
+    {
+        $this->repository = $repository;
+        $this->validator  = $validator;
+    }
+
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+
+        $this->repository->pushCriteria(app('Prettus\Repository\Criteria\RequestCriteria'));
+        $$PLURAL$ = $this->repository->all();
+
+        if (request()->wantsJson()) {
+
+            return response()->json([
+                'data' => $$PLURAL$,
+            ]);
+        }
+
+        return view('$PLURAL$.index', compact('$PLURAL$'));
+    }
+
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+
+        return view('$PLURAL$.create');
+    }
+
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  $CLASS$CreateRequest $request
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function store($CLASS$CreateRequest $request)
+    {
+
+        try {
+
+            $this->validator->with($request->all())->passesOrFail(ValidatorInterface::RULE_CREATE);
+
+            $$SINGULAR$ = $this->repository->create($request->all());
+
+            $response = [
+                'message' => '$CLASS$ created.',
+                'data'    => $$SINGULAR$->toArray(),
+            ];
+
+            if ($request->wantsJson()) {
+
+                return response()->json($response);
+            }
+
+            return redirect()->back()->with('message', $response['message']);
+        } catch (ValidatorException $e) {
+            if ($request->wantsJson()) {
+                return response()->json([
+                    'error'   => true,
+                    'message' => $e->getMessage()
+                ]);
+            }
+
+            return redirect()->back()->withErrors($e->getMessageBag())->withInput();
+        }
+    }
+
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int $id
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        $$SINGULAR$ = $this->repository->find($id);
+
+        if (request()->wantsJson()) {
+
+            return response()->json([
+                'data' => $$SINGULAR$,
+            ]);
+        }
+
+        return view('$PLURAL$.show', compact('$SINGULAR$'));
+    }
+
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int $id
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+
+        $$SINGULAR$ = $this->repository->find($id);
+
+        return view('$PLURAL$.edit', compact('$SINGULAR$'));
+    }
+
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  $CLASS$UpdateRequest $request
+     * @param  string            $id
+     *
+     * @return Response
+     */
+    public function update($CLASS$UpdateRequest $request, $id)
+    {
+
+        try {
+
+            $this->validator->with($request->all())->passesOrFail(ValidatorInterface::RULE_UPDATE);
+
+            $$SINGULAR$ = $this->repository->update($request->all(), $id);
+
+            $response = [
+                'message' => '$CLASS$ updated.',
+                'data'    => $$SINGULAR$->toArray(),
+            ];
+
+            if ($request->wantsJson()) {
+
+                return response()->json($response);
+            }
+
+            return redirect()->back()->with('message', $response['message']);
+        } catch (ValidatorException $e) {
+
+            if ($request->wantsJson()) {
+
+                return response()->json([
+                    'error'   => true,
+                    'message' => $e->getMessage()
+                ]);
+            }
+
+            return redirect()->back()->withErrors($e->getMessageBag())->withInput();
+        }
+    }
+
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int $id
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        $deleted = $this->repository->delete($id);
+
+        if (request()->wantsJson()) {
+
+            return response()->json([
+                'message' => '$CLASS$ deleted.',
+                'deleted' => $deleted,
+            ]);
+        }
+
+        return redirect()->back()->with('message', '$CLASS$ deleted.');
+    }
+}

--- a/src/Prettus/Repository/Providers/RepositoryServiceProvider.php
+++ b/src/Prettus/Repository/Providers/RepositoryServiceProvider.php
@@ -9,12 +9,15 @@ use Illuminate\Support\ServiceProvider;
  */
 class RepositoryServiceProvider extends ServiceProvider
 {
+
     /**
      * Indicates if loading of the provider is deferred.
      *
      * @var bool
      */
     protected $defer = false;
+
+
     /**
      *
      * @return void
@@ -25,12 +28,11 @@ class RepositoryServiceProvider extends ServiceProvider
             __DIR__ . '/../../../resources/config/repository.php' => config_path('repository.php')
         ]);
 
-        $this->mergeConfigFrom(
-            __DIR__ . '/../../../resources/config/repository.php', 'repository'
-        );
+        $this->mergeConfigFrom(__DIR__ . '/../../../resources/config/repository.php', 'repository');
 
         $this->loadTranslationsFrom(__DIR__ . '/../../../resources/lang', 'repository');
     }
+
 
     /**
      * Register the service provider.
@@ -44,8 +46,10 @@ class RepositoryServiceProvider extends ServiceProvider
         $this->commands('Prettus\Repository\Generators\Commands\PresenterCommand');
         $this->commands('Prettus\Repository\Generators\Commands\EntityCommand');
         $this->commands('Prettus\Repository\Generators\Commands\ValidatorCommand');
+        $this->commands('Prettus\Repository\Generators\Commands\ControllerCommand');
         $this->app->register('Prettus\Repository\Providers\EventServiceProvider');
     }
+
 
     /**
      * Get the services provided by the provider.
@@ -54,6 +58,6 @@ class RepositoryServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return [];
+        return [ ];
     }
 }

--- a/src/Prettus/Repository/Providers/RepositoryServiceProvider.php
+++ b/src/Prettus/Repository/Providers/RepositoryServiceProvider.php
@@ -47,6 +47,7 @@ class RepositoryServiceProvider extends ServiceProvider
         $this->commands('Prettus\Repository\Generators\Commands\EntityCommand');
         $this->commands('Prettus\Repository\Generators\Commands\ValidatorCommand');
         $this->commands('Prettus\Repository\Generators\Commands\ControllerCommand');
+        $this->commands('Prettus\Repository\Generators\Commands\BindingsCommand');
         $this->app->register('Prettus\Repository\Providers\EventServiceProvider');
     }
 

--- a/src/resources/config/repository.php
+++ b/src/resources/config/repository.php
@@ -227,6 +227,7 @@ return [
             'transformers' => 'Transformers',
             'presenters'   => 'Presenters',
             'validators'   => 'Validators',
+            'controllers'   => 'Http/Controllers',
         ]
     ]
 ];

--- a/src/resources/config/repository.php
+++ b/src/resources/config/repository.php
@@ -168,7 +168,8 @@ return [
         |
         */
         'acceptedConditions' => [
-            '=','like'
+            '=',
+            'like'
         ],
         /*
         |--------------------------------------------------------------------------
@@ -227,7 +228,8 @@ return [
             'transformers' => 'Transformers',
             'presenters'   => 'Presenters',
             'validators'   => 'Validators',
-            'controllers'   => 'Http/Controllers',
+            'controllers'  => 'Http/Controllers',
+            'provider'     => 'RepositoryServiceProvider',
         ]
     ]
 ];


### PR DESCRIPTION
Added basic REST CRUD operations into a stub controller.

The command will generate the controllers as well as the RepositoryServiceProvider to bind repository interface and repository eloquent:


     art make:entity Cat --fillable="name:string" --rules="name=>required|min:2"

All you need to do is to add this into your app/Providers/AppServiceProvider.php@register method:

    $this->app->register(RepositoryServiceProvider::class);


The name can be modified from `config/repository.php`:

    'generator'  => [
        'paths'         => [
            'provider'       => 'RepositoryServiceProvider',


