### PR TITLE
Added force generators option

### DIFF
--- a/src/Prettus/Repository/Generators/Commands/TransformerCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/TransformerCommand.php
@@ -3,6 +3,7 @@ namespace Prettus\Repository\Generators\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
+use Prettus\Repository\Generators\FileAlreadyExistsException;
 use Prettus\Repository\Generators\TransformerGenerator;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -25,17 +26,30 @@ class TransformerCommand extends Command
     protected $description = 'Create a new transformer.';
 
     /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Transformer';
+
+    /**
      * Execute the command.
      *
      * @return void
      */
     public function fire()
     {
-        (new TransformerGenerator([
-            'name'  => $this->argument('name'),
-            'force' => $this->option('force'),
-        ]))->run();
-        $this->info("Transformer created successfully.");
+        try {
+            (new TransformerGenerator([
+                'name'  => $this->argument('name'),
+                'force' => $this->option('force'),
+            ]))->run();
+            $this->info("Transformer created successfully.");
+        } catch (FileAlreadyExistsException $e) {
+            $this->error($this->type . ' already exists!');
+
+            return false;
+        }
     }
 
 

--- a/src/Prettus/Repository/Generators/Commands/ValidatorCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/ValidatorCommand.php
@@ -3,6 +3,7 @@ namespace Prettus\Repository\Generators\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
+use Prettus\Repository\Generators\FileAlreadyExistsException;
 use Prettus\Repository\Generators\ValidatorGenerator;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -24,6 +25,13 @@ class ValidatorCommand extends Command
      */
     protected $description = 'Create a new validator.';
 
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Validator';
+
 
     /**
      * Execute the command.
@@ -32,12 +40,18 @@ class ValidatorCommand extends Command
      */
     public function fire()
     {
-        (new ValidatorGenerator([
-            'name'  => $this->argument('name'),
-            'rules' => $this->option('rules'),
-            'force' => $this->option('force'),
-        ]))->run();
-        $this->info("Validator created successfully.");
+        try {
+            (new ValidatorGenerator([
+                'name'  => $this->argument('name'),
+                'rules' => $this->option('rules'),
+                'force' => $this->option('force'),
+            ]))->run();
+            $this->info("Validator created successfully.");
+        } catch (FileAlreadyExistsException $e) {
+            $this->error($this->type . ' already exists!');
+
+            return false;
+        }
     }
 
 

--- a/src/Prettus/Repository/Generators/Stubs/repository/eloquent.stub
+++ b/src/Prettus/Repository/Generators/Stubs/repository/eloquent.stub
@@ -6,7 +6,7 @@ use Prettus\Repository\Eloquent\BaseRepository;
 use Prettus\Repository\Criteria\RequestCriteria;
 use $REPOSITORY$
 use $MODEL$;
-$USE_VALIDATOR$;
+$USE_VALIDATOR$
 
 /**
  * Class $CLASS$RepositoryEloquent


### PR DESCRIPTION
Changed the way that existing file error was handled to the Laravel command way

- Removed the FileAlreadyExistsException and show error message in console for already created files.
- Added --force options for generators to override existing files if wanted