### PR TITLE
Enable relations in fieldSearchable

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,12 +546,13 @@ class PostRepository extends BaseRepository {
 
 Remember, you need to define which fields from the model can be searchable.
 
-In your repository set **$fieldSearchable** with the name of the fields to be searchable.
+In your repository set **$fieldSearchable** with the name of the fields to be searchable or a relation to fields.
 
 ```php
 protected $fieldSearchable = [
 	'name',
-	'email'
+	'email',
+	'product.name'
 ];
 ```
 
@@ -564,6 +565,7 @@ protected $fieldSearchable = [
 	'your_field'=>'condition'
 ];
 ```
+
 
 ####Enabling in your Controller
 

--- a/src/Prettus/Repository/Criteria/RequestCriteria.php
+++ b/src/Prettus/Repository/Criteria/RequestCriteria.php
@@ -75,14 +75,32 @@ class RequestCriteria implements CriteriaInterface
                         }
                     }
 
-                    if ($isFirstField || $modelForceAndWhere) {
+                    $relation = null;
+                    if(stripos($field, '.')) {
+                        $explode = explode('.', $field);
+                        $field = array_pop($explode);
+                        $relation = implode('.', $explode);
+                    }
+                    if ( $isFirstField || $modelForceAndWhere ) {
                         if (!is_null($value)) {
-                            $query->where($field, $condition, $value);
+                            if(!is_null($relation)) {
+                                $query->whereHas($relation, function($query) use($field,$condition,$value) {
+                                    $query->where($field,$condition,$value);
+                                });
+                            } else {
+                                $query->where($field,$condition,$value);
+                            }
                             $isFirstField = false;
                         }
                     } else {
                         if (!is_null($value)) {
-                            $query->orWhere($field, $condition, $value);
+                            if(!is_null($relation)) {
+                                $query->orWhereHas($relation, function($query) use($field,$condition,$value) {
+                                    $query->where($field,$condition,$value);
+                                });
+                            } else {
+                                $query->orWhere($field, $condition, $value);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Relations can now be used when using $fieldSearchable

ex.

$fieldSearchable = [
   'comments.title' => 'like',
   'location.city.name'
];