### PR TITLE
Ability to sort through related tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,33 @@ Sorting the results
 ]
 ```
 
+Sorting through related tables
+
+`http://prettus.local/users?orderBy=posts|title&sortedBy=desc`
+
+Query will have something like this
+
+```sql
+...
+INNER JOIN posts ON users.post_id = posts.id
+...
+ORDER BY title
+...
+```
+
+`http://prettus.local/users?orderBy=posts:custom_id|posts.title&sortedBy=desc`
+
+Query will have something like this
+
+```sql
+...
+INNER JOIN posts ON users.custom_id = posts.id
+...
+ORDER BY posts.title
+...
+```
+
+
 Add relationship
 
 `http://prettus.local/users?with=groups`

--- a/src/Prettus/Repository/Criteria/RequestCriteria.php
+++ b/src/Prettus/Repository/Criteria/RequestCriteria.php
@@ -110,6 +110,13 @@ class RequestCriteria implements CriteriaInterface
         if (isset($orderBy) && !empty($orderBy)) {
             $split = explode('|', $orderBy);
             if(count($split) > 1) {
+                /*
+                 * ex.
+                 * products|description -> join products on current_table.product_id = products.id order by description
+                 * 
+                 * products:custom_id|products.description -> join products on current_table.custom_id = products.id order
+                 * by products.description (in case both tables have same column name)
+                 */
                 $table = $model->getModel()->getTable();
                 $sortTable = $split[0];
                 $sortColumn = $split[1];
@@ -119,6 +126,13 @@ class RequestCriteria implements CriteriaInterface
                     $sortTable = $split[0];
                     $keyName = $table.'.'.$split[1];
                 } else {
+                    /*
+                     * If you do not define which column to use as a joining column on current table, it will
+                     * use a singular of a join table appended with _id
+                     *
+                     * ex.
+                     * products -> product_id
+                     */
                     $prefix = rtrim($sortTable, 's');
                     $keyName = $table.'.'.$prefix.'_id';
                 }

--- a/src/Prettus/Repository/Criteria/RequestCriteria.php
+++ b/src/Prettus/Repository/Criteria/RequestCriteria.php
@@ -108,7 +108,28 @@ class RequestCriteria implements CriteriaInterface
         }
 
         if (isset($orderBy) && !empty($orderBy)) {
-            $model = $model->orderBy($orderBy, $sortedBy);
+            $split = explode('|', $orderBy);
+            if(count($split) > 1) {
+                $table = $model->getModel()->getTable();
+                $sortTable = $split[0];
+                $sortColumn = $split[1];
+
+                $split = explode(':', $sortTable);
+                if(count($split) > 1) {
+                    $sortTable = $split[0];
+                    $keyName = $table.'.'.$split[1];
+                } else {
+                    $prefix = rtrim($sortTable, 's');
+                    $keyName = $table.'.'.$prefix.'_id';
+                }
+
+                $model = $model
+                    ->join($sortTable, $keyName, '=', $sortTable.'.id')
+                    ->orderBy($sortColumn, $sortedBy)
+                    ->addSelect($table.'.*');
+            } else {
+                $model = $model->orderBy($orderBy, $sortedBy);
+            }
         }
 
         if (isset($filter) && !empty($filter)) {


### PR DESCRIPTION
I've made a simple change that enables to sort through related tables. So for example if you want to sort all users by created_at column in posts table, Laravel unfortunately cannot accomplish that using `with` but by joining tables. You can now using orderBy parameter join two tables and sort by column in other table.

ex. 
`http://prettus.local/users?orderBy=posts|title&sortedBy=desc`
```sql
INNER JOIN posts ON users.post_id = posts.id
ORDER BY title DESC
```
delimiter is `|` and separates which table to join and which column to sort by in the joined table.

or even
`http://prettus.local/users?orderBy=posts:custom_id|posts.title&sortedBy=desc`
```sql
INNER JOIN posts ON users.custom_id = posts.id
ORDER BY posts.title DESC
```
 
delimiter is `:` is used to define a custom column to be used in parent table for joining