### PR TITLE
make:resource command fix for incorrect repository namespace

### DIFF
--- a/src/Prettus/Repository/Generators/ControllerGenerator.php
+++ b/src/Prettus/Repository/Generators/ControllerGenerator.php
@@ -133,7 +133,7 @@ class ControllerGenerator extends Generator
      */
     public function getRepository()
     {
-        $repositoryGenerator = new RepositoryEloquentGenerator([
+        $repositoryGenerator = new RepositoryInterfaceGenerator([
             'name' => $this->name,
         ]);
 


### PR DESCRIPTION
Repository namespace is incorrect in the controllers when `make:resource` command is used if the `interface` generators namespace is changed in the `repository.php` config file.