### PR TITLE
Ambiguous column fix

### DIFF
--- a/src/Prettus/Repository/Criteria/RequestCriteria.php
+++ b/src/Prettus/Repository/Criteria/RequestCriteria.php
@@ -81,6 +81,7 @@ class RequestCriteria implements CriteriaInterface
                         $field = array_pop($explode);
                         $relation = implode('.', $explode);
                     }
+                    $modelTableName = $query->getModel()->getTable();
                     if ( $isFirstField || $modelForceAndWhere ) {
                         if (!is_null($value)) {
                             if(!is_null($relation)) {
@@ -88,7 +89,7 @@ class RequestCriteria implements CriteriaInterface
                                     $query->where($field,$condition,$value);
                                 });
                             } else {
-                                $query->where($field,$condition,$value);
+                                $query->where($modelTableName.'.'.$field,$condition,$value);
                             }
                             $isFirstField = false;
                         }
@@ -99,7 +100,7 @@ class RequestCriteria implements CriteriaInterface
                                     $query->where($field,$condition,$value);
                                 });
                             } else {
-                                $query->orWhere($field, $condition, $value);
+                                $query->orWhere($modelTableName.'.'.$field, $condition, $value);
                             }
                         }
                     }


### PR DESCRIPTION
This solves and issue with ambiguous column. Example when error happens:

```php
$fieldSearchable = [
   'id' => 'like',
   'post.title' => 'like'
];
```

Since there is join happening id becomes ambiguous. This fix appends table name to that column.