### PR TITLE
Properly handles paths during generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Create your repositories easily through the generator.
 
 #### Config
 
-You must first configure the storage location of the repository files. By default is the "app" folder and the namespace "App".
+You must first configure the storage location of the repository files. By default is the "app" folder and the namespace "App". Please note that, values in the `paths` array are acutally used as both *namespace* and file paths. Relax though, both foreward and backward slashes are taken care of during generation.
 
 ```php
     ...

--- a/src/Prettus/Repository/Generators/Generator.php
+++ b/src/Prettus/Repository/Generators/Generator.php
@@ -211,7 +211,10 @@ abstract class Generator
 
         if ($directoryPath) {
             $path = str_replace('\\', '/', $path);
+        } else {
+            $path = str_replace('/', '\\', $path);
         }
+        
 
         return $path;
     }


### PR DESCRIPTION
Makes sure that both directory & namespace paths are correctly returned from the `Generator::getConfigGeneratorClassPath()` method.

And also adds notes to readme.md