### PR TITLE
Fix table name convention for migration when making a entity.

### DIFF
--- a/src/Prettus/Repository/Generators/Commands/RepositoryCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/RepositoryCommand.php
@@ -51,7 +51,7 @@ class RepositoryCommand extends Command
         $this->generators = new Collection();
 
         $this->generators->push(new MigrationGenerator([
-            'name'   => 'create_' . str_plural(strtolower($this->argument('name'))) . '_table',
+            'name'   => 'create_' . snake_case(str_plural($this->argument('name'))) . '_table',
             'fields' => $this->option('fillable'),
             'force'  => $this->option('force'),
         ]));


### PR DESCRIPTION
Ex: `php artisan make:entity MarketArea` generates `Schema::create('marketareas')` in migration file originally, and the eloquent model `MarketArea` won't work.