### PR TITLE
Fix lists method

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Create your repositories easily through the generator.
 
 #### Config
 
-You must first configure the storage location of the repository files. By default is the "app" folder and the namespace "App".
+You must first configure the storage location of the repository files. By default is the "app" folder and the namespace "App". Please note that, values in the `paths` array are acutally used as both *namespace* and file paths. Relax though, both foreward and backward slashes are taken care of during generation.
 
 ```php
     ...

--- a/src/Prettus/Repository/Criteria/RequestCriteria.php
+++ b/src/Prettus/Repository/Criteria/RequestCriteria.php
@@ -81,6 +81,7 @@ class RequestCriteria implements CriteriaInterface
                         $field = array_pop($explode);
                         $relation = implode('.', $explode);
                     }
+                    $modelTableName = $query->getModel()->getTable();
                     if ( $isFirstField || $modelForceAndWhere ) {
                         if (!is_null($value)) {
                             if(!is_null($relation)) {
@@ -88,7 +89,7 @@ class RequestCriteria implements CriteriaInterface
                                     $query->where($field,$condition,$value);
                                 });
                             } else {
-                                $query->where($field,$condition,$value);
+                                $query->where($modelTableName.'.'.$field,$condition,$value);
                             }
                             $isFirstField = false;
                         }
@@ -99,7 +100,7 @@ class RequestCriteria implements CriteriaInterface
                                     $query->where($field,$condition,$value);
                                 });
                             } else {
-                                $query->orWhere($field, $condition, $value);
+                                $query->orWhere($modelTableName.'.'.$field, $condition, $value);
                             }
                         }
                     }

--- a/src/Prettus/Repository/Criteria/RequestCriteria.php
+++ b/src/Prettus/Repository/Criteria/RequestCriteria.php
@@ -138,7 +138,7 @@ class RequestCriteria implements CriteriaInterface
                 }
 
                 $model = $model
-                    ->join($sortTable, $keyName, '=', $sortTable.'.id')
+                    ->leftJoin($sortTable, $keyName, '=', $sortTable.'.id')
                     ->orderBy($sortColumn, $sortedBy)
                     ->addSelect($table.'.*');
             } else {

--- a/src/Prettus/Repository/Eloquent/BaseRepository.php
+++ b/src/Prettus/Repository/Eloquent/BaseRepository.php
@@ -615,7 +615,7 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
 
     public function orderBy($column, $direction = 'asc')
     {
-        $this->model = $this->model->query()->orderBy($column, $direction);
+        $this->model = $this->model->orderBy($column, $direction);
 
         return $this;
     }

--- a/src/Prettus/Repository/Eloquent/BaseRepository.php
+++ b/src/Prettus/Repository/Eloquent/BaseRepository.php
@@ -262,7 +262,9 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
      */
     public function lists($column, $key = null)
     {
-        return $this->makeModel()->lists($column, $key);
+        $this->applyCriteria();
+        
+        return $this->model->lists($column, $key);
     }
 
     /**

--- a/src/Prettus/Repository/Generators/Commands/RepositoryCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/RepositoryCommand.php
@@ -51,7 +51,7 @@ class RepositoryCommand extends Command
         $this->generators = new Collection();
 
         $this->generators->push(new MigrationGenerator([
-            'name'   => 'create_' . str_plural(strtolower($this->argument('name'))) . '_table',
+            'name'   => 'create_' . snake_case(str_plural($this->argument('name'))) . '_table',
             'fields' => $this->option('fillable'),
             'force'  => $this->option('force'),
         ]));

--- a/src/Prettus/Repository/Generators/Generator.php
+++ b/src/Prettus/Repository/Generators/Generator.php
@@ -211,7 +211,10 @@ abstract class Generator
 
         if ($directoryPath) {
             $path = str_replace('\\', '/', $path);
+        } else {
+            $path = str_replace('/', '\\', $path);
         }
+        
 
         return $path;
     }


### PR DESCRIPTION
A suggestion if you want it. The lists method inside BaseRespository should use applyCriteria() so orderBy can be performed easier when querying. I also changed makeModel() to $this->model as there is no need to call the method at this point.

I should mention I did this after trying several times to get the scopeQuery to work and failed.