### PR TITLE
fix wrong order of repository's update params

### DIFF
--- a/src/Prettus/Repository/Generators/Stubs/controller/controller.stub
+++ b/src/Prettus/Repository/Generators/Stubs/controller/controller.stub
@@ -146,7 +146,7 @@ class $CONTROLLER$Controller extends Controller
 
             $this->validator->with($request->all())->passesOrFail(ValidatorInterface::RULE_UPDATE);
 
-            $$SINGULAR$ = $this->repository->update($id, $request->all());
+            $$SINGULAR$ = $this->repository->update($request->all(), $id);
 
             $response = [
                 'message' => '$CLASS$ updated.',


### PR DESCRIPTION
The update params should be `$attributes` first then `$id` 
`public function update(array $attributes, $id)`