### PR TITLE
Lumen compatibility, generators fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ You must first configure the storage location of the repository files. By defaul
 ```php
     ...
     'generator'=>[
-        'basePath'=>app_path(),
+        'basePath'=>app()->path(),
         'rootNamespace'=>'App\\',
         'paths'=>[
             'models'       => 'Entities',
@@ -223,7 +223,7 @@ Additionally, you may wish to customize where your generated classes end up bein
 
 ```php
     'generator'=>[
-        'basePath'=>app_path(),
+        'basePath'=>app()->path(),
         'rootNamespace'=>'App\\',
         'paths'=>[
             'models'=>'Models',

--- a/src/Prettus/Repository/Generators/BindingsGenerator.php
+++ b/src/Prettus/Repository/Generators/BindingsGenerator.php
@@ -49,7 +49,7 @@ class BindingsGenerator extends Generator
      */
     public function getBasePath()
     {
-        return config('repository.generator.basePath', app_path());
+        return config('repository.generator.basePath', app()->path());
     }
 
     /**

--- a/src/Prettus/Repository/Generators/Commands/PresenterCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/PresenterCommand.php
@@ -2,6 +2,7 @@
 namespace Prettus\Repository\Generators\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
 use Prettus\Repository\Generators\FileAlreadyExistsException;
 use Prettus\Repository\Generators\PresenterGenerator;
 use Prettus\Repository\Generators\TransformerGenerator;
@@ -48,7 +49,9 @@ class PresenterCommand extends Command
             ]))->run();
             $this->info("Presenter created successfully.");
 
-            if (!\File::exists(app_path() . '/Transformers/' . $this->argument('name') . 'Transformer.php')) {
+            $filesystem = new Filesystem();
+
+            if (!$filesystem->exists(app()->path() . '/Transformers/' . $this->argument('name') . 'Transformer.php')) {
                 if ($this->confirm('Would you like to create a Transformer? [y|N]')) {
                     (new TransformerGenerator([
                         'name'  => $this->argument('name'),

--- a/src/Prettus/Repository/Generators/ControllerGenerator.php
+++ b/src/Prettus/Repository/Generators/ControllerGenerator.php
@@ -52,7 +52,7 @@ class ControllerGenerator extends Generator
      */
     public function getBasePath()
     {
-        return config('repository.generator.basePath', app_path());
+        return config('repository.generator.basePath', app()->path());
     }
 
     /**

--- a/src/Prettus/Repository/Generators/CriteriaGenerator.php
+++ b/src/Prettus/Repository/Generators/CriteriaGenerator.php
@@ -51,6 +51,6 @@ class CriteriaGenerator extends Generator
      */
     public function getBasePath()
     {
-        return config('repository.generator.basePath', app_path());
+        return config('repository.generator.basePath', app()->path());
     }
 }

--- a/src/Prettus/Repository/Generators/Generator.php
+++ b/src/Prettus/Repository/Generators/Generator.php
@@ -2,14 +2,11 @@
 
 namespace Prettus\Repository\Generators;
 
-use Illuminate\Console\AppNamespaceDetectorTrait;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 
 abstract class Generator
 {
-
-    use AppNamespaceDetectorTrait;
 
     /**
      * The filesystem instance.
@@ -110,7 +107,7 @@ abstract class Generator
      */
     public function getBasePath()
     {
-        return base_path();
+        return app()->basePath();
     }
 
 
@@ -176,6 +173,23 @@ abstract class Generator
         return config('repository.generator.rootNamespace', $this->getAppNamespace());
     }
 
+    /**
+     * @return int|string
+     * @throws RuntimeException
+     */
+    public function getAppNamespace()
+    {
+        $composer = json_decode(file_get_contents(base_path('composer.json')), true);
+        foreach ((array) data_get($composer, 'autoload.psr-4') as $namespace => $path) {
+            foreach ((array) $path as $pathChoice) {
+                if (realpath(app()->path()) == realpath(app()->basePath().'/'.$pathChoice)) {
+                    return $namespace;
+                }
+            }
+        }
+        throw new RuntimeException('Unable to detect application namespace.');
+    }
+
 
     /**
      * Get class-specific output paths.
@@ -229,6 +243,9 @@ abstract class Generator
     }
 
 
+    /**
+     * @return mixed
+     */
     abstract public function getPathConfigNode();
 
 

--- a/src/Prettus/Repository/Generators/MigrationGenerator.php
+++ b/src/Prettus/Repository/Generators/MigrationGenerator.php
@@ -28,7 +28,7 @@ class MigrationGenerator extends Generator
      */
     public function getBasePath()
     {
-        return base_path() . '/database/migrations/';
+        return app()->basePath() . '/database/migrations/';
     }
 
 

--- a/src/Prettus/Repository/Generators/ModelGenerator.php
+++ b/src/Prettus/Repository/Generators/ModelGenerator.php
@@ -56,7 +56,7 @@ class ModelGenerator extends Generator
 
     public function getBasePath()
     {
-        return config('repository.generator.basePath', app_path());
+        return config('repository.generator.basePath', app()->path());
     }
 
     /**

--- a/src/Prettus/Repository/Generators/PresenterGenerator.php
+++ b/src/Prettus/Repository/Generators/PresenterGenerator.php
@@ -74,6 +74,6 @@ class PresenterGenerator extends Generator
      */
     public function getBasePath()
     {
-        return config('repository.generator.basePath', app_path());
+        return config('repository.generator.basePath', app()->path());
     }
 }

--- a/src/Prettus/Repository/Generators/RepositoryEloquentGenerator.php
+++ b/src/Prettus/Repository/Generators/RepositoryEloquentGenerator.php
@@ -54,7 +54,7 @@ class RepositoryEloquentGenerator extends Generator
      */
     public function getBasePath()
     {
-        return config('repository.generator.basePath', app_path());
+        return config('repository.generator.basePath', app()->path());
     }
 
     /**

--- a/src/Prettus/Repository/Generators/RepositoryInterfaceGenerator.php
+++ b/src/Prettus/Repository/Generators/RepositoryInterfaceGenerator.php
@@ -55,7 +55,7 @@ class RepositoryInterfaceGenerator extends Generator
      */
     public function getBasePath()
     {
-        return config('repository.generator.basePath', app_path());
+        return config('repository.generator.basePath', app()->path());
     }
 
     /**

--- a/src/Prettus/Repository/Generators/TransformerGenerator.php
+++ b/src/Prettus/Repository/Generators/TransformerGenerator.php
@@ -52,7 +52,7 @@ class TransformerGenerator extends Generator
      */
     public function getBasePath()
     {
-        return config('repository.generator.basePath', app_path());
+        return config('repository.generator.basePath', app()->path());
     }
 
     /**

--- a/src/Prettus/Repository/Generators/ValidatorGenerator.php
+++ b/src/Prettus/Repository/Generators/ValidatorGenerator.php
@@ -55,7 +55,7 @@ class ValidatorGenerator extends Generator
      */
     public function getBasePath()
     {
-        return config('repository.generator.basePath', app_path());
+        return config('repository.generator.basePath', app()->path());
     }
 
     /**

--- a/src/Prettus/Repository/Providers/LumenRepositoryServiceProvider.php
+++ b/src/Prettus/Repository/Providers/LumenRepositoryServiceProvider.php
@@ -36,6 +36,8 @@ class LumenRepositoryServiceProvider extends ServiceProvider
         $this->commands(ValidatorCommand::class);
         $this->commands(ControllerCommand::class);
         $this->app->register(EventServiceProvider::class);
+
+        $this->app->configure('repository');
     }
 
     /**

--- a/src/Prettus/Repository/Providers/LumenRepositoryServiceProvider.php
+++ b/src/Prettus/Repository/Providers/LumenRepositoryServiceProvider.php
@@ -2,6 +2,12 @@
 namespace Prettus\Repository\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Prettus\Repository\Generators\Commands\ControllerCommand;
+use Prettus\Repository\Generators\Commands\EntityCommand;
+use Prettus\Repository\Generators\Commands\PresenterCommand;
+use Prettus\Repository\Generators\Commands\RepositoryCommand;
+use Prettus\Repository\Generators\Commands\TransformerCommand;
+use Prettus\Repository\Generators\Commands\ValidatorCommand;
 
 /**
  * Class LumenRepositoryServiceProvider
@@ -23,8 +29,13 @@ class LumenRepositoryServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->commands('Prettus\Repository\Generators\Commands\RepositoryCommand');
-        $this->app->register('Prettus\Repository\Providers\EventServiceProvider');
+        $this->commands(RepositoryCommand::class);
+        $this->commands(TransformerCommand::class);
+        $this->commands(PresenterCommand::class);
+        $this->commands(EntityCommand::class);
+        $this->commands(ValidatorCommand::class);
+        $this->commands(ControllerCommand::class);
+        $this->app->register(EventServiceProvider::class);
     }
 
     /**

--- a/src/resources/config/repository.php
+++ b/src/resources/config/repository.php
@@ -219,7 +219,7 @@ return [
     |
     */
     'generator'  => [
-        'basePath'      => app_path(),
+        'basePath'      => app()->path(),
         'rootNamespace' => 'App\\',
         'paths'         => [
             'models'       => 'Entities',
@@ -231,7 +231,7 @@ return [
             'controllers'  => 'Http/Controllers',
             'provider'     => 'RepositoryServiceProvider',
             'criteria'     => 'Criteria',
-            'stubsOverridePath' => app_path()
+            'stubsOverridePath' => app()->path()
         ]
     ]
 ];


### PR DESCRIPTION
Fix #179 and `app_path()` - `base_path()` uses `app()->path()` and `app->basePath()` instead which are valid in both Lumen and Laravel Application Container.