### PR TITLE
Fixes validation error when attribute is marked as hidden & fillable (Issue #225)

### DIFF
--- a/src/Prettus/Repository/Eloquent/BaseRepository.php
+++ b/src/Prettus/Repository/Eloquent/BaseRepository.php
@@ -454,7 +454,10 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
             // we should pass data that has been casts by the model
             // to make sure data type are same because validator may need to use
             // this data to compare with data that fetch from database.
-            $attributes = $this->model->newInstance()->forceFill($attributes)->toArray();
+            $attributes = $this->model->newInstance()
+                ->forceFill($attributes)
+                ->makeVisible($this->model->getHidden())
+                ->toArray();
 
             $this->validator->with($attributes)->passesOrFail(ValidatorInterface::RULE_CREATE);
         }
@@ -486,7 +489,10 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
             // we should pass data that has been casts by the model
             // to make sure data type are same because validator may need to use
             // this data to compare with data that fetch from database.
-            $attributes = $this->model->newInstance()->forceFill($attributes)->toArray();
+            $attributes = $this->model->newInstance()
+                ->forceFill($attributes)
+                ->makeVisible($this->model->getHidden())
+                ->toArray();
 
             $this->validator->with($attributes)->setId($id)->passesOrFail(ValidatorInterface::RULE_UPDATE);
         }

--- a/src/Prettus/Repository/Generators/RepositoryEloquentGenerator.php
+++ b/src/Prettus/Repository/Generators/RepositoryEloquentGenerator.php
@@ -142,7 +142,7 @@ class RepositoryEloquentGenerator extends Generator
 
         $class = $this->getClass();
 
-        return '/**' . PHP_EOL . '    * Specify Validator class name' . PHP_EOL . '    *' . PHP_EOL . '    * @return mixed' . PHP_EOL . '    */' . PHP_EOL . '    public function validator()' . PHP_EOL . '    {' . PHP_EOL . PHP_EOL . '        return ' . $class . 'Validator::class;' . PHP_EOL . '    }' . PHP_EOL;
+        return '/**' . PHP_EOL . '     * Specify Validator class name' . PHP_EOL . '     *' . PHP_EOL . '     * @return mixed' . PHP_EOL . '     */' . PHP_EOL . '    public function validator()' . PHP_EOL . '    {' . PHP_EOL . PHP_EOL . '        return ' . $class . 'Validator::class;' . PHP_EOL . '    }' . PHP_EOL;
 
     }
 }


### PR DESCRIPTION
This fixes the issue when a field is mass assignable but also hidden. An example of this is the default Laravel User class. The password field is mass assignable but it is hidden from output.

This solution gets all attributes from the model before validation. This is safe as the attributes are only used on the validation and have nothing to do with the model that is actioned on.