### PR TITLE
Fixes simplePagination with CacheRepository

### DIFF
--- a/src/Prettus/Repository/Traits/CacheableRepository.php
+++ b/src/Prettus/Repository/Traits/CacheableRepository.php
@@ -216,20 +216,21 @@ trait CacheableRepository
      *
      * @param null  $limit
      * @param array $columns
+     * @param string $method
      *
      * @return mixed
      */
-    public function paginate($limit = null, $columns = ['*'])
+    public function paginate($limit = null, $columns = ['*'], $method = "paginate")
     {
         if (!$this->allowedCache('paginate') || $this->isSkippedCache()) {
-            return parent::paginate($limit, $columns);
+            return parent::paginate($limit, $columns, $method);
         }
 
         $key = $this->getCacheKey('paginate', func_get_args());
 
         $minutes = $this->getCacheMinutes();
-        $value = $this->getCacheRepository()->remember($key, $minutes, function () use ($limit, $columns) {
-            return parent::paginate($limit, $columns);
+        $value = $this->getCacheRepository()->remember($key, $minutes, function () use ($limit, $columns, $method) {
+            return parent::paginate($limit, $columns, $method);
         });
 
         return $value;


### PR DESCRIPTION
currently if we do

`$foo= $this->fooRepository->simplePaginate(); ` with CacheRepository, it will return \Illuminate\Pagination\LengthAwarePaginator instead of the expected Illuminate\Pagination\Paginator

this PR will fix this issue.