### PR TITLE
Add $pageName option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ php artisan vendor:publish
 
 - all($columns = array('*'))
 - first($columns = array('*'))
-- paginate($limit = null, $columns = ['*'])
+- paginate($limit = null, $columns = ['*'], $pageName = 'page')
 - find($id, $columns = ['*'])
 - findByField($field, $value, $columns = ['*'])
 - findWhere(array $where, $columns = ['*'])
@@ -340,7 +340,7 @@ $posts = $this->repository->all();
 Find all results in Repository with pagination
 
 ```php
-$posts = $this->repository->paginate($limit = null, $columns = ['*']);
+$posts = $this->repository->paginate($limit = null, $columns = ['*'], $pageName = 'page');
 ```
 
 Find by result by id

--- a/src/Prettus/Repository/Eloquent/BaseRepository.php
+++ b/src/Prettus/Repository/Eloquent/BaseRepository.php
@@ -263,7 +263,7 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
     public function lists($column, $key = null)
     {
         $this->applyCriteria();
-        
+
         return $this->model->lists($column, $key);
     }
 
@@ -316,16 +316,17 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
      *
      * @param null   $limit
      * @param array  $columns
+     * @param string $pageName
      * @param string $method
      *
      * @return mixed
      */
-    public function paginate($limit = null, $columns = ['*'], $method = "paginate")
+    public function paginate($limit = null, $columns = ['*'], $pageName = 'page', $method = "paginate")
     {
         $this->applyCriteria();
         $this->applyScope();
         $limit = is_null($limit) ? config('repository.pagination.limit', 15) : $limit;
-        $results = $this->model->{$method}($limit, $columns);
+        $results = $this->model->{$method}($limit, $columns, $pageName);
         $results->appends(app('request')->query());
         $this->resetModel();
 
@@ -619,7 +620,7 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
 
         return $this;
     }
-    
+
     /**
      * Load relation with closure
      *


### PR DESCRIPTION
Add `$pageName` to be able to use an other name than ‘page’ for pagination, like in the Laravel method

https://laravel.com/api/5.2/Illuminate/Database/Eloquent/Builder.html#method_paginate