### PR TITLE
Modificação para laravel 5.3

### DIFF
--- a/src/Prettus/Repository/Eloquent/BaseRepository.php
+++ b/src/Prettus/Repository/Eloquent/BaseRepository.php
@@ -264,7 +264,7 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
     {
         $this->applyCriteria();
         
-        return $this->model->lists($column, $key);
+        return $this->model->pluck($column, $key);
     }
 
     /**


### PR DESCRIPTION
Adaptação para laravel versão 5.3, onde o comando lists foi descontinuado. Correção informática, precisa tratar a versão do laravel.