### PR TITLE
Add whereHas() method to RepositoryInterface contract.

### DIFF
--- a/src/Prettus/Repository/Contracts/RepositoryInterface.php
+++ b/src/Prettus/Repository/Contracts/RepositoryInterface.php
@@ -167,7 +167,7 @@ interface RepositoryInterface
      *
      * @return $this
      */
-    function whereHas($relation, $closure);
+    public function whereHas($relation, $closure);
     
     /**
      * Set hidden fields

--- a/src/Prettus/Repository/Contracts/RepositoryInterface.php
+++ b/src/Prettus/Repository/Contracts/RepositoryInterface.php
@@ -158,7 +158,17 @@ interface RepositoryInterface
      * @return $this
      */
     public function with($relations);
-
+    
+    /**
+     * Load relation with closure
+     *
+     * @param string $relation
+     * @param closure $closure
+     *
+     * @return $this
+     */
+    function whereHas($relation, $closure);
+    
     /**
      * Set hidden fields
      *

--- a/src/Prettus/Repository/Eloquent/BaseRepository.php
+++ b/src/Prettus/Repository/Eloquent/BaseRepository.php
@@ -628,7 +628,7 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
      *
      * @return $this
      */
-    function whereHas($relation, $closure)
+    public function whereHas($relation, $closure)
     {
         $this->model = $this->model->whereHas($relation, $closure);
 


### PR DESCRIPTION
I noticed the whereHas() method was missing from the RepositoryInterface contract--which is not exactly clean code and freaks PHPStorm out.

Also, whereHas() in the BaseRepository needed a visibility.