### PR TITLE
Laravel 5.4 Compatibility

### DIFF
--- a/src/Prettus/Repository/Generators/Generator.php
+++ b/src/Prettus/Repository/Generators/Generator.php
@@ -2,14 +2,14 @@
 
 namespace Prettus\Repository\Generators;
 
-use Illuminate\Console\AppNamespaceDetectorTrait;
+use Illuminate\Console\DetectsApplicationNamespace;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
 
 abstract class Generator
 {
 
-    use AppNamespaceDetectorTrait;
+    use DetectsApplicationNamespace;
 
     /**
      * The filesystem instance.


### PR DESCRIPTION
From the 5.4 upgrade guide:

> If you are directly referencing the `Illuminate\Console\AppNamespaceDetectorTrait` trait, update 
your code to reference `Illuminate\Console\DetectsApplicationNamespace` instead.

I am new to PHP and Laravel, not sure how to make this change compatible for other versions of Laravel. Please advice, I'll update the PR.