### PR TITLE
Add new feature for RequestCriteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,22 @@ or
 ]
 ```
 
+By default RequestCriteria makes its queries using the **OR** comparison operator for each query parameter.
+`http://prettus.local/users?search=age:17;email:john@gmail.com`
+
+The above example will execute the following query:
+``` sql
+SELECT * FROM users WHERE age = 17 OR email = 'john@gmail.com';
+```
+
+In order for it to query using the **AND**, pass the *searchJoin* parameter as shown below:
+
+`http://prettus.local/users?search=age:17;email:john@gmail.com&searchJoin=and`
+
+
+
+
+
 Filtering fields
 
 `http://prettus.local/users?filter=id;name`

--- a/src/Prettus/Repository/Criteria/RequestCriteria.php
+++ b/src/Prettus/Repository/Criteria/RequestCriteria.php
@@ -42,6 +42,7 @@ class RequestCriteria implements CriteriaInterface
         $orderBy = $this->request->get(config('repository.criteria.params.orderBy', 'orderBy'), null);
         $sortedBy = $this->request->get(config('repository.criteria.params.sortedBy', 'sortedBy'), 'asc');
         $with = $this->request->get(config('repository.criteria.params.with', 'with'), null);
+        $searchJoin = $this->request->get(config('repository.criteria.params.searchJoin', 'searchJoin'), null);
         $sortedBy = !empty($sortedBy) ? $sortedBy : 'asc';
 
         if ($search && is_array($fieldsSearchable) && count($fieldsSearchable)) {
@@ -51,7 +52,7 @@ class RequestCriteria implements CriteriaInterface
             $isFirstField = true;
             $searchData = $this->parserSearchData($search);
             $search = $this->parserSearchValue($search);
-            $modelForceAndWhere = false;
+            $modelForceAndWhere = strtolower($searchJoin) === 'and';
 
             $model = $model->where(function ($query) use ($fields, $search, $searchData, $isFirstField, $modelForceAndWhere) {
                 /** @var Builder $query */
@@ -114,7 +115,7 @@ class RequestCriteria implements CriteriaInterface
                 /*
                  * ex.
                  * products|description -> join products on current_table.product_id = products.id order by description
-                 * 
+                 *
                  * products:custom_id|products.description -> join products on current_table.custom_id = products.id order
                  * by products.description (in case both tables have same column name)
                  */

--- a/src/resources/config/repository.php
+++ b/src/resources/config/repository.php
@@ -202,6 +202,12 @@ return [
         |   http://prettus.local/?search=lorem&orderBy=id&sortedBy=asc
         |   http://prettus.local/?search=lorem&orderBy=id&sortedBy=desc
         |
+        | - searchJoin: Specifies the search method (AND / OR), by default the
+        |               application searches each parameter with OR
+        |   EX:
+        |   http://prettus.local/?search=lorem&searchJoin=and
+        |   http://prettus.local/?search=lorem&searchJoin=or
+        |
         */
         'params'             => [
             'search'       => 'search',
@@ -209,7 +215,8 @@ return [
             'filter'       => 'filter',
             'orderBy'      => 'orderBy',
             'sortedBy'     => 'sortedBy',
-            'with'         => 'with'
+            'with'         => 'with',
+            'searchJoin'   => 'searchJoin'            
         ]
     ],
     /*


### PR DESCRIPTION
Created a new parameter used to set modelForceAndWhere in query in RequestCriteria.

Now is possible pass the `searchJoin=and` in the request for set modelForceAndWhere as **true**.


I make the documentation in README.