### PR TITLE
Fix BaseRepository::sync()

### DIFF
--- a/src/Prettus/Repository/Eloquent/BaseRepository.php
+++ b/src/Prettus/Repository/Eloquent/BaseRepository.php
@@ -293,7 +293,7 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
      */
     public function sync($id, $relation, $attributes, $detaching = true)
     {
-        return $this->find($id)->getRelation($relation)->sync($attributes, $detaching);
+        return $this->find($id)->{$relation}()->sync($attributes, $detaching);
     }
 
     /**


### PR DESCRIPTION
Prevent "[BadMethodCallException] Method sync does not exist" exception