### PR TITLE
Add firstOrCreate method

### DIFF
--- a/src/Prettus/Repository/Contracts/RepositoryInterface.php
+++ b/src/Prettus/Repository/Contracts/RepositoryInterface.php
@@ -275,4 +275,13 @@ interface RepositoryInterface
      * @return mixed
      */
     public function firstOrNew(array $attributes = []);
+
+    /**
+     * Retrieve first data of repository, or create new Entity
+     *
+     * @param array $attributes
+     *
+     * @return mixed
+     */
+    public function firstOrCreate(array $attributes = []);
 }

--- a/src/Prettus/Repository/Eloquent/BaseRepository.php
+++ b/src/Prettus/Repository/Eloquent/BaseRepository.php
@@ -377,6 +377,29 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
     }
 
     /**
+     * Retrieve first data of repository, or create new Entity
+     *
+     * @param array $attributes
+     *
+     * @return mixed
+     */
+    public function firstOrCreate(array $attributes = [])
+    {
+        $this->applyCriteria();
+        $this->applyScope();
+
+        $temporarySkipPresenter = $this->skipPresenter;
+        $this->skipPresenter(true);
+
+        $model = $this->model->firstOrCreate($attributes);
+        $this->skipPresenter($temporarySkipPresenter);
+
+        $this->resetModel();
+
+        return $this->parserResult($model);
+    }
+
+    /**
      * Retrieve all data of repository, paginated
      *
      * @param null $limit


### PR DESCRIPTION
Hello guys,

Do you accept this PR to add the firstOrCreate method to the BaseRepository?

I noticed that the firstOrNew method exists in [BaseRepository](https://github.com/andersao/l5-repository/blob/master/src/Prettus/Repository/Eloquent/BaseRepository.php#L363). So I think the firstOrCreate method can be very useful.

Thank you!