### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,7 +532,7 @@ You can perform a dynamic search, filter the data and customize the queries.
 
 To use the Criteria in your repository, you can add a new criteria in the boot method of your repository, or directly use in your controller, in order to filter out only a few requests.
 
-####Enabling in your Repository
+#### Enabling in your Repository
 
 ```php
 use Prettus\Repository\Eloquent\BaseRepository;
@@ -583,7 +583,7 @@ protected $fieldSearchable = [
 ```
 
 
-####Enabling in your Controller
+#### Enabling in your Controller
 
 ```php
 	public function index()
@@ -733,7 +733,7 @@ Add relationship
 
 
 
-####Overwrite params name
+#### Overwrite params name
 
 You can change the name of the parameters in the configuration file **config/repository.php**
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
