### PR TITLE
Replace fire() with handle() for 5.5 compatibility

### DIFF
--- a/src/Prettus/Repository/Generators/Commands/BindingsCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/BindingsCommand.php
@@ -39,7 +39,7 @@ class BindingsCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         try {
             $bindingGenerator = new BindingsGenerator([

--- a/src/Prettus/Repository/Generators/Commands/ControllerCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/ControllerCommand.php
@@ -38,7 +38,7 @@ class ControllerCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         try {
             // Generate create request for controller

--- a/src/Prettus/Repository/Generators/Commands/CriteriaCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/CriteriaCommand.php
@@ -35,7 +35,7 @@ class CriteriaCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         try {
             (new CriteriaGenerator([

--- a/src/Prettus/Repository/Generators/Commands/EntityCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/EntityCommand.php
@@ -34,7 +34,7 @@ class EntityCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
 
         if ($this->confirm('Would you like to create a Presenter? [y|N]')) {

--- a/src/Prettus/Repository/Generators/Commands/PresenterCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/PresenterCommand.php
@@ -38,7 +38,7 @@ class PresenterCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
 
         try {

--- a/src/Prettus/Repository/Generators/Commands/RepositoryCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/RepositoryCommand.php
@@ -46,7 +46,7 @@ class RepositoryCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->generators = new Collection();
 

--- a/src/Prettus/Repository/Generators/Commands/TransformerCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/TransformerCommand.php
@@ -37,7 +37,7 @@ class TransformerCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         try {
             (new TransformerGenerator([

--- a/src/Prettus/Repository/Generators/Commands/ValidatorCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/ValidatorCommand.php
@@ -38,7 +38,7 @@ class ValidatorCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         try {
             (new ValidatorGenerator([


### PR DESCRIPTION
This bring the generator back to work for laravel 5.5 because of this recent commit laravel/framework@ac9f29da4785c8b942ced8c4ab308214d618a22b