### PR TITLE
enable generator commands for lumen

### DIFF
--- a/src/Prettus/Repository/Providers/LumenRepositoryServiceProvider.php
+++ b/src/Prettus/Repository/Providers/LumenRepositoryServiceProvider.php
@@ -24,6 +24,13 @@ class LumenRepositoryServiceProvider extends ServiceProvider
     public function register()
     {
         $this->commands('Prettus\Repository\Generators\Commands\RepositoryCommand');
+        $this->commands('Prettus\Repository\Generators\Commands\TransformerCommand');
+        $this->commands('Prettus\Repository\Generators\Commands\PresenterCommand');
+        $this->commands('Prettus\Repository\Generators\Commands\EntityCommand');
+        $this->commands('Prettus\Repository\Generators\Commands\ValidatorCommand');
+        $this->commands('Prettus\Repository\Generators\Commands\ControllerCommand');
+        $this->commands('Prettus\Repository\Generators\Commands\BindingsCommand');
+        $this->commands('Prettus\Repository\Generators\Commands\CriteriaCommand');
         $this->app->register('Prettus\Repository\Providers\EventServiceProvider');
     }
 


### PR DESCRIPTION
Hello dear, I installed the repo on a lumen project. When i wanted to use the generators, i saw that they aren't enabled so i enable them on lumen service provider. 

Here is a PR. It would be great if you accept the PR so people can also use the generators in their lumen projects. 

Many thanks.