### PR TITLE
Add Feature to Decode IDs (i.e., HashIDs)

### DIFF
--- a/src/Prettus/Repository/Contracts/RepositoryInterface.php
+++ b/src/Prettus/Repository/Contracts/RepositoryInterface.php
@@ -284,4 +284,18 @@ interface RepositoryInterface
      * @return mixed
      */
     public function firstOrCreate(array $attributes = []);
+
+    /**
+     * Retrieves the name of the field where hashed ID is stored
+     *
+     * @return string
+     */
+    public function getHashIDKey();
+
+    /**
+     * Retrieves the name of the method used to decode the hashed id
+     *
+     * @return string
+     */
+    public function getHashIDDecoder();
 }

--- a/src/Prettus/Repository/Criteria/RequestCriteria.php
+++ b/src/Prettus/Repository/Criteria/RequestCriteria.php
@@ -54,6 +54,25 @@ class RequestCriteria implements CriteriaInterface
             $search = $this->parserSearchValue($search);
             $modelForceAndWhere = strtolower($searchJoin) === 'and';
 
+            // this block replaces the hashed id with the decoded (real) id
+            // check, if we have hashed ids
+            if(config('repository.criteria.hashids', false)) {
+
+                $hashIDKey = $repository->getHashIDKey();
+                $hashIDDecoder = $repository->getHashIDDecoder();
+
+                if($hashIDKey && $hashIDDecoder) {
+                    // check, if the hashIDKey is present in the search array
+                    if (array_key_exists($hashIDKey, $searchData)) {
+
+                        // and check, if there is a respective decoder method available
+                        if (method_exists($model, $hashIDDecoder)) {
+                            $searchData[$hashIDKey] = $model->{$hashIDDecoder}($searchData[$hashIDKey]);
+                        }
+                    }
+                }
+            }
+
             $model = $model->where(function ($query) use ($fields, $search, $searchData, $isFirstField, $modelForceAndWhere) {
                 /** @var Builder $query */
 

--- a/src/Prettus/Repository/Eloquent/BaseRepository.php
+++ b/src/Prettus/Repository/Eloquent/BaseRepository.php
@@ -83,6 +83,20 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
     protected $scopeQuery = null;
 
     /**
+     * Default value for the name of the field where the hashed id is stored
+     *
+     * @var string
+     */
+    protected $hashIDKey = 'id';
+
+    /**
+     * Default value for the name of the method to decode the hashed id
+     *
+     * @var string
+     */
+    protected $hashIDDecoder = 'decode';
+
+    /**
      * @param Application $app
      */
     public function __construct(Application $app)
@@ -332,7 +346,6 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
 
         return $this->parserResult($results);
     }
-
 
     /**
      * Retrieve first data of repository
@@ -982,5 +995,25 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
         }
 
         return $result;
+    }
+
+    /**
+     * Retrieves the name of the field where hashed ID is stored
+     *
+     * @return string
+     */
+    public function getHashIDKey()
+    {
+        return $this->hashIDKey;
+    }
+
+    /**
+     * Retrieves the name of the method used to decode the hashed id
+     *
+     * @return string
+     */
+    public function getHashIDDecoder()
+    {
+        return $this->hashIDDecoder;
     }
 }

--- a/src/resources/config/repository.php
+++ b/src/resources/config/repository.php
@@ -209,15 +209,17 @@ return [
         |   http://prettus.local/?search=lorem&searchJoin=or
         |
         */
-        'params'             => [
+        'params'           => [
             'search'       => 'search',
             'searchFields' => 'searchFields',
             'filter'       => 'filter',
             'orderBy'      => 'orderBy',
             'sortedBy'     => 'sortedBy',
             'with'         => 'with',
-            'searchJoin'   => 'searchJoin'            
-        ]
+            'searchJoin'   => 'searchJoin',
+        ],
+
+        'hashids' => false,
     ],
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Hey @andersao , @eullercdr ,

This is a PR that fixes #427 .
The feature can be enabled via the config file. Furthermore, each repository controls the respective parameters (e.g., the name of the field that contains the ID and the method of the model to decode the ID).

Any recommendations / suggestions?

Cheers