### PR TITLE
migration namespace directory tree bugfix - fixes #440

### DIFF
--- a/src/Prettus/Repository/Generators/Commands/RepositoryCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/RepositoryCommand.php
@@ -61,7 +61,7 @@ class RepositoryCommand extends Command
         $this->generators = new Collection();
 
         $migrationGenerator = new MigrationGenerator([
-            'name'   => 'create_' . snake_case(str_plural($this->argument('name'))) . '_table',
+            'name'   => 'create_' . snake_case(str_plural(str_replace('/','',$this->argument('name')))) . '_table',
             'fields' => $this->option('fillable'),
             'force'  => $this->option('force'),
         ]);


### PR DESCRIPTION
Hi! when i use make:repository or make:entity command and set repository with namespacess like
Api/Public/SomeScope/SomeRepo migration for this repository make directory tree

    2017_09_26_044722_create_api
        _public
            _some_scope
                _some_repos_table.php

default artisan:migrate command ignore folders in /database/migrations directory, so i need rename and move migration file for every entity with namespace and remove directory tree
mv 2017_09_26_044722_create_api/_public/_some_scope/_some_repos_table.php
2017_09_26_044722_create_api_public_some_scope_some_repos_table.php

rm -rf 2017_09_26_044722_create_api/_public/_some_scope

it isn't critical bug, but i spend time to move migration file.

P.S Thx for awesome lib, if i use it with deefour/interactor i can create DDD-like project simply, easy and fast.

issue - https://github.com/andersao/l5-repository/issues/440