### PR TITLE
hotfix make:entity and change make:resource to make:rest-controller

### DIFF
--- a/src/Prettus/Repository/Generators/Commands/ControllerCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/ControllerCommand.php
@@ -16,7 +16,7 @@ class ControllerCommand extends Command
      *
      * @var string
      */
-    protected $name = 'make:rest-controller';
+    protected $name = 'make:resource';
 
     /**
      * The description of command.
@@ -31,6 +31,15 @@ class ControllerCommand extends Command
      * @var string
      */
     protected $type = 'Controller';
+
+    /**
+     * ControllerCommand constructor.
+     */
+    public function __construct()
+    {
+        $this->name = ((float) app()->version() >= 5.5  ? 'make:rest-controller' : 'make:resource');
+        parent::__construct();
+    }
 
     /**
      * Execute the command.
@@ -54,6 +63,7 @@ class ControllerCommand extends Command
             $this->call('make:request', [
                 'name' => $this->argument('name') . 'CreateRequest'
             ]);
+
             // Generate update request for controller
             $this->call('make:request', [
                 'name' => $this->argument('name') . 'UpdateRequest'
@@ -63,7 +73,9 @@ class ControllerCommand extends Command
                 'name' => $this->argument('name'),
                 'force' => $this->option('force'),
             ]))->run();
+
             $this->info($this->type . ' created successfully.');
+
         } catch (FileAlreadyExistsException $e) {
             $this->error($this->type . ' already exists!');
 

--- a/src/Prettus/Repository/Generators/Commands/ControllerCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/ControllerCommand.php
@@ -16,14 +16,14 @@ class ControllerCommand extends Command
      *
      * @var string
      */
-    protected $name = 'make:resource';
+    protected $name = 'make:rest-controller';
 
     /**
      * The description of command.
      *
      * @var string
      */
-    protected $description = 'Create a new RESTfull controller.';
+    protected $description = 'Create a new RESTful controller.';
 
     /**
      * The type of class being generated.

--- a/src/Prettus/Repository/Generators/Commands/EntityCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/EntityCommand.php
@@ -67,7 +67,7 @@ class EntityCommand extends Command
             ]);
         }
 
-        if ($this->confirm('Would you like to create a Controller? [y|N]')) {
+        if ($this->confirm('Would you like to create a RESTful Controller? [y|N]')) {
 
             $resource_args = [
                 'name'    => $this->argument('name')
@@ -79,7 +79,7 @@ class EntityCommand extends Command
             }
 
             // Generate a controller resource
-            $this->call('make:resource',$resource_args);
+            $this->call('make:rest-controller',$resource_args);
         }
 
         $this->call('make:repository', [

--- a/src/Prettus/Repository/Generators/Commands/EntityCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/EntityCommand.php
@@ -28,7 +28,6 @@ class EntityCommand extends Command
      */
     protected $generators = null;
 
-
     /**
      * Execute the command.
      *
@@ -67,19 +66,15 @@ class EntityCommand extends Command
             ]);
         }
 
-        if ($this->confirm('Would you like to create a RESTful Controller? [y|N]')) {
+        if ($this->confirm('Would you like to create a Controller? [y|N]')) {
 
             $resource_args = [
                 'name'    => $this->argument('name')
             ];
 
-            // The command "make:resource" in laravel 5.5 don't support option '--force'
-            if( (float) app()->version() <= 5.4 ){
-                $resource_args['--force'] = $this->option('force');
-            }
-
             // Generate a controller resource
-            $this->call('make:rest-controller',$resource_args);
+            $controller_command = ((float) app()->version() >= 5.5  ? 'make:rest-controller' : 'make:resource');
+            $this->call($controller_command, $resource_args);
         }
 
         $this->call('make:repository', [


### PR DESCRIPTION
Because Laravel5.5 new feature - make:resource command cause this package
make:resource broken, change command to fix it.

ref: [Laravel 5.5: API Resources](https://laracasts.com/series/whats-new-in-laravel-5-5/episodes/20)

issue: https://github.com/andersao/l5-repository/issues/435