### PR TITLE
Update RequestCriteria.php - Fix bug with singularising join tables on sorts

### DIFF
--- a/src/Prettus/Repository/Criteria/RequestCriteria.php
+++ b/src/Prettus/Repository/Criteria/RequestCriteria.php
@@ -135,7 +135,7 @@ class RequestCriteria implements CriteriaInterface
                      * ex.
                      * products -> product_id
                      */
-                    $prefix = rtrim($sortTable, 's');
+                    $prefix = str_singular($sortTable);
                     $keyName = $table.'.'.$prefix.'_id';
                 }
 


### PR DESCRIPTION
Correct the singular for sort table as at the moment it doesnt work for words such as countries. it just turns it into: countrie instead of country