### PR TITLE
 Support for configuring parent classes

### DIFF
--- a/src/Prettus/Repository/Generators/ControllerGenerator.php
+++ b/src/Prettus/Repository/Generators/ControllerGenerator.php
@@ -96,14 +96,14 @@ class ControllerGenerator extends Generator
     {
 
         return array_merge(parent::getReplacements(), [
-            'controller' => $this->getControllerName(),
-            'plural'     => $this->getPluralName(),
-            'singular'   => $this->getSingularName(),
-            'validator'  => $this->getValidator(),
-            'repository' => $this->getRepository(),
-            'appname'    => $this->getAppNamespace(),
-            'parent_class'    => $this->getParentClass(),
-            'parent_class_name'    => $this->getParentClassName(),
+            'controller'        => $this->getControllerName(),
+            'plural'            => $this->getPluralName(),
+            'singular'          => $this->getSingularName(),
+            'validator'         => $this->getValidator(),
+            'repository'        => $this->getRepository(),
+            'appname'           => $this->getAppNamespace(),
+            'parent_class'      => $this->getParentClass(),
+            'parent_class_name' => $this->getParentClassName(),
         ]);
     }
 

--- a/src/Prettus/Repository/Generators/ControllerGenerator.php
+++ b/src/Prettus/Repository/Generators/ControllerGenerator.php
@@ -36,6 +36,16 @@ class ControllerGenerator extends Generator
     }
 
     /**
+     * Get parent class config node.
+     *
+     * @return string
+     */
+    public function getParentClassConfigNode()
+    {
+        return 'controller';
+    }
+
+    /**
      * Get destination path for generated file.
      *
      * @return string
@@ -92,6 +102,8 @@ class ControllerGenerator extends Generator
             'validator'  => $this->getValidator(),
             'repository' => $this->getRepository(),
             'appname'    => $this->getAppNamespace(),
+            'parent_class'    => $this->getParentClass(),
+            'parent_class_name'    => $this->getParentClassName(),
         ]);
     }
 

--- a/src/Prettus/Repository/Generators/Generator.php
+++ b/src/Prettus/Repository/Generators/Generator.php
@@ -248,31 +248,31 @@ abstract class Generator
     {
         switch ($class) {
             case ('model' === $class):
-                $path = config('repository.generator.parentClasses.model', \Illuminate\Database\Eloquent\Model::class);
+                $parentClass = config('repository.generator.parentClasses.model', \Illuminate\Database\Eloquent\Model::class);
                 break;
             case ('repository' === $class):
-                $path = config('repository.generator.parentClasses.repository', Prettus\Repository\Eloquent\BaseRepository::class);
+                $parentClass = config('repository.generator.parentClasses.repository', Prettus\Repository\Eloquent\BaseRepository::class);
                 break;
             case ('interface' === $class):
-                $path = config('repository.generator.parentClasses.interface', Prettus\Repository\Contracts\RepositoryInterface::class);
+                $parentClass = config('repository.generator.parentClasses.interface', Prettus\Repository\Contracts\RepositoryInterface::class);
                 break;
             case ('presenter' === $class):
-                $path = config('repository.generator.parentClasses.presenter', Prettus\Repository\Presenter\FractalPresenter::class);
+                $parentClass = config('repository.generator.parentClasses.presenter', Prettus\Repository\Presenter\FractalPresenter::class);
                 break;
             case ('transformer' === $class):
-                $path = config('repository.generator.parentClasses.transformer', League\Fractal\TransformerAbstract::class);
+                $parentClass = config('repository.generator.parentClasses.transformer', League\Fractal\TransformerAbstract::class);
                 break;
             case ('validator' === $class):
-                $path = config('repository.generator.parentClasses.validator', \Prettus\Validator\LaravelValidator::class);
+                $parentClass = config('repository.generator.parentClasses.validator', \Prettus\Validator\LaravelValidator::class);
                 break;
             case ('controller' === $class):
-                $path = config('repository.generator.parentClasses.controller', App\Http\Controllers\Controller::class);
+                $parentClass = config('repository.generator.parentClasses.controller', App\Http\Controllers\Controller::class);
                 break;
             default:
-                $path = '';
+                $parentClass = '';
         }
 
-        return $path;
+        return $parentClass;
     }
 
 
@@ -311,6 +311,11 @@ abstract class Generator
         return $this->getConfigGeneratorParentClass($this->getParentClassConfigNode());
     }
 
+    /**
+     * Gets parent class full class name.
+     *
+     * @return string
+     */
     public function getParentClass()
     {
         return 'use ' . $this->getParentClassNamespace() . ';';
@@ -318,7 +323,7 @@ abstract class Generator
 
 
     /**
-     * Get parent class namespace.
+     * Get parent class name.
      *
      * @return string
      */

--- a/src/Prettus/Repository/Generators/Generator.php
+++ b/src/Prettus/Repository/Generators/Generator.php
@@ -237,7 +237,50 @@ abstract class Generator
     }
 
 
+    /**
+     * Get class-specific parent class.
+     *
+     * @param $class
+     *
+     * @return string
+     */
+    public function getConfigGeneratorParentClass($class)
+    {
+        switch ($class) {
+            case ('model' === $class):
+                $path = config('repository.generator.parentClasses.model', \Illuminate\Database\Eloquent\Model::class);
+                break;
+            case ('repository' === $class):
+                $path = config('repository.generator.parentClasses.repository', Prettus\Repository\Eloquent\BaseRepository::class);
+                break;
+            case ('interface' === $class):
+                $path = config('repository.generator.parentClasses.interface', Prettus\Repository\Contracts\RepositoryInterface::class);
+                break;
+            case ('presenter' === $class):
+                $path = config('repository.generator.parentClasses.presenter', Prettus\Repository\Presenter\FractalPresenter::class);
+                break;
+            case ('transformer' === $class):
+                $path = config('repository.generator.parentClasses.transformer', League\Fractal\TransformerAbstract::class);
+                break;
+            case ('validator' === $class):
+                $path = config('repository.generator.parentClasses.validator', \Prettus\Validator\LaravelValidator::class);
+                break;
+            case ('controller' === $class):
+                $path = config('repository.generator.parentClasses.controller', App\Http\Controllers\Controller::class);
+                break;
+            default:
+                $path = '';
+        }
+
+        return $path;
+    }
+
+
     abstract public function getPathConfigNode();
+
+    public function getParentClassConfigNode() {
+        return '';
+    }
 
 
     /**
@@ -255,6 +298,34 @@ abstract class Generator
         }
 
         return 'namespace ' . rtrim($rootNamespace . '\\' . implode($segments, '\\'), '\\') . ';';
+    }
+
+
+    /**
+     * Get parent class namespace.
+     *
+     * @return string
+     */
+    public function getParentClassNamespace()
+    {
+        return $this->getConfigGeneratorParentClass($this->getParentClassConfigNode());
+    }
+
+    public function getParentClass()
+    {
+        return 'use ' . $this->getParentClassNamespace() . ';';
+    }
+
+
+    /**
+     * Get parent class namespace.
+     *
+     * @return string
+     */
+    public function getParentClassName()
+    {
+        $array = explode('\\', $this->getParentClassNamespace());
+        return end($array);
     }
 
 

--- a/src/Prettus/Repository/Generators/ModelGenerator.php
+++ b/src/Prettus/Repository/Generators/ModelGenerator.php
@@ -39,6 +39,16 @@ class ModelGenerator extends Generator
     }
 
     /**
+     * Get parent class config node.
+     *
+     * @return string
+     */
+    public function getParentClassConfigNode()
+    {
+        return 'model';
+    }
+
+    /**
      * Get destination path for generated file.
      *
      * @return string
@@ -67,7 +77,9 @@ class ModelGenerator extends Generator
     public function getReplacements()
     {
         return array_merge(parent::getReplacements(), [
-            'fillable' => $this->getFillable()
+            'fillable' => $this->getFillable(),
+            'parent_class'    => $this->getParentClass(),
+            'parent_class_name'    => $this->getParentClassName(),
         ]);
     }
 

--- a/src/Prettus/Repository/Generators/ModelGenerator.php
+++ b/src/Prettus/Repository/Generators/ModelGenerator.php
@@ -77,9 +77,9 @@ class ModelGenerator extends Generator
     public function getReplacements()
     {
         return array_merge(parent::getReplacements(), [
-            'fillable' => $this->getFillable(),
-            'parent_class'    => $this->getParentClass(),
-            'parent_class_name'    => $this->getParentClassName(),
+            'fillable'          => $this->getFillable(),
+            'parent_class'      => $this->getParentClass(),
+            'parent_class_name' => $this->getParentClassName(),
         ]);
     }
 

--- a/src/Prettus/Repository/Generators/PresenterGenerator.php
+++ b/src/Prettus/Repository/Generators/PresenterGenerator.php
@@ -63,9 +63,9 @@ class PresenterGenerator extends Generator
         echo $transformer;
 
         return array_merge(parent::getReplacements(), [
-            'transformer' => $transformer,
-            'parent_class'    => $this->getParentClass(),
-            'parent_class_name'    => $this->getParentClassName(),
+            'transformer'       => $transformer,
+            'parent_class'      => $this->getParentClass(),
+            'parent_class_name' => $this->getParentClassName(),
         ]);
     }
 

--- a/src/Prettus/Repository/Generators/PresenterGenerator.php
+++ b/src/Prettus/Repository/Generators/PresenterGenerator.php
@@ -36,6 +36,16 @@ class PresenterGenerator extends Generator
     }
 
     /**
+     * Get parent class config node.
+     *
+     * @return string
+     */
+    public function getParentClassConfigNode()
+    {
+        return 'presenter';
+    }
+
+    /**
      * Get array replacements.
      *
      * @return array
@@ -53,7 +63,9 @@ class PresenterGenerator extends Generator
         echo $transformer;
 
         return array_merge(parent::getReplacements(), [
-            'transformer' => $transformer
+            'transformer' => $transformer,
+            'parent_class'    => $this->getParentClass(),
+            'parent_class_name'    => $this->getParentClassName(),
         ]);
     }
 

--- a/src/Prettus/Repository/Generators/RepositoryEloquentGenerator.php
+++ b/src/Prettus/Repository/Generators/RepositoryEloquentGenerator.php
@@ -81,13 +81,13 @@ class RepositoryEloquentGenerator extends Generator
         ], '\\', $repository);
 
         return array_merge(parent::getReplacements(), [
-            'fillable'      => $this->getFillable(),
-            'use_validator' => $this->getValidatorUse(),
-            'validator'     => $this->getValidatorMethod(),
-            'repository'    => $repository,
-            'model'         => isset($this->options['model']) ? $this->options['model'] : '',
-            'parent_class'    => $this->getParentClass(),
-            'parent_class_name'    => $this->getParentClassName(),
+            'fillable'          => $this->getFillable(),
+            'use_validator'     => $this->getValidatorUse(),
+            'validator'         => $this->getValidatorMethod(),
+            'repository'        => $repository,
+            'model'             => isset($this->options['model']) ? $this->options['model'] : '',
+            'parent_class'      => $this->getParentClass(),
+            'parent_class_name' => $this->getParentClassName(),
         ]);
     }
 

--- a/src/Prettus/Repository/Generators/RepositoryEloquentGenerator.php
+++ b/src/Prettus/Repository/Generators/RepositoryEloquentGenerator.php
@@ -38,6 +38,16 @@ class RepositoryEloquentGenerator extends Generator
     }
 
     /**
+     * Get parent class config node.
+     *
+     * @return string
+     */
+    public function getParentClassConfigNode()
+    {
+        return 'repository';
+    }
+
+    /**
      * Get destination path for generated file.
      *
      * @return string
@@ -75,7 +85,9 @@ class RepositoryEloquentGenerator extends Generator
             'use_validator' => $this->getValidatorUse(),
             'validator'     => $this->getValidatorMethod(),
             'repository'    => $repository,
-            'model'         => isset($this->options['model']) ? $this->options['model'] : ''
+            'model'         => isset($this->options['model']) ? $this->options['model'] : '',
+            'parent_class'    => $this->getParentClass(),
+            'parent_class_name'    => $this->getParentClassName(),
         ]);
     }
 

--- a/src/Prettus/Repository/Generators/RepositoryInterfaceGenerator.php
+++ b/src/Prettus/Repository/Generators/RepositoryInterfaceGenerator.php
@@ -39,6 +39,16 @@ class RepositoryInterfaceGenerator extends Generator
     }
 
     /**
+     * Get parent class config node.
+     *
+     * @return string
+     */
+    public function getParentClassConfigNode()
+    {
+        return 'interface';
+    }
+
+    /**
      * Get destination path for generated file.
      *
      * @return string
@@ -66,7 +76,9 @@ class RepositoryInterfaceGenerator extends Generator
     public function getReplacements()
     {
         return array_merge(parent::getReplacements(), [
-            'fillable' => $this->getFillable()
+            'fillable' => $this->getFillable(),
+            'parent_class'    => $this->getParentClass(),
+            'parent_class_name'    => $this->getParentClassName(),
         ]);
     }
 

--- a/src/Prettus/Repository/Generators/RepositoryInterfaceGenerator.php
+++ b/src/Prettus/Repository/Generators/RepositoryInterfaceGenerator.php
@@ -76,9 +76,9 @@ class RepositoryInterfaceGenerator extends Generator
     public function getReplacements()
     {
         return array_merge(parent::getReplacements(), [
-            'fillable' => $this->getFillable(),
-            'parent_class'    => $this->getParentClass(),
-            'parent_class_name'    => $this->getParentClassName(),
+            'fillable'          => $this->getFillable(),
+            'parent_class'      => $this->getParentClass(),
+            'parent_class_name' => $this->getParentClassName(),
         ]);
     }
 

--- a/src/Prettus/Repository/Generators/Stubs/controller/controller.stub
+++ b/src/Prettus/Repository/Generators/Stubs/controller/controller.stub
@@ -4,6 +4,7 @@ $NAMESPACE$
 
 use Illuminate\Http\Request;
 
+$PARENT_CLASS$
 use $APPNAME$Http\Requests;
 use Prettus\Validator\Contracts\ValidatorInterface;
 use Prettus\Validator\Exceptions\ValidatorException;
@@ -13,7 +14,7 @@ $REPOSITORY$
 $VALIDATOR$
 
 
-class $CONTROLLER$Controller extends Controller
+class $CONTROLLER$Controller extends $PARENT_CLASS_NAME$
 {
 
     /**

--- a/src/Prettus/Repository/Generators/Stubs/model.stub
+++ b/src/Prettus/Repository/Generators/Stubs/model.stub
@@ -2,11 +2,11 @@
 
 $NAMESPACE$
 
-use Illuminate\Database\Eloquent\Model;
+$PARENT_CLASS$
 use Prettus\Repository\Contracts\Transformable;
 use Prettus\Repository\Traits\TransformableTrait;
 
-class $CLASS$ extends Model implements Transformable
+class $CLASS$ extends $PARENT_CLASS_NAME$ implements Transformable
 {
     use TransformableTrait;
 

--- a/src/Prettus/Repository/Generators/Stubs/presenter/presenter.stub
+++ b/src/Prettus/Repository/Generators/Stubs/presenter/presenter.stub
@@ -3,14 +3,14 @@
 $NAMESPACE$
 
 use $TRANSFORMER$;
-use Prettus\Repository\Presenter\FractalPresenter;
+$PARENT_CLASS$
 
 /**
  * Class $CLASS$Presenter
  *
  * @package $NAMESPACE$
  */
-class $CLASS$Presenter extends FractalPresenter
+class $CLASS$Presenter extends $PARENT_CLASS_NAME$
 {
     /**
      * Transformer

--- a/src/Prettus/Repository/Generators/Stubs/repository/eloquent.stub
+++ b/src/Prettus/Repository/Generators/Stubs/repository/eloquent.stub
@@ -2,7 +2,7 @@
 
 $NAMESPACE$
 
-use Prettus\Repository\Eloquent\BaseRepository;
+$PARENT_CLASS$
 use Prettus\Repository\Criteria\RequestCriteria;
 use $REPOSITORY$
 use $MODEL$;
@@ -12,7 +12,7 @@ $USE_VALIDATOR$
  * Class $CLASS$RepositoryEloquent
  * @package $NAMESPACE$
  */
-class $CLASS$RepositoryEloquent extends BaseRepository implements $CLASS$Repository
+class $CLASS$RepositoryEloquent extends $PARENT_CLASS_NAME$ implements $CLASS$Repository
 {
     /**
      * Specify Model class name

--- a/src/Prettus/Repository/Generators/Stubs/repository/interface.stub
+++ b/src/Prettus/Repository/Generators/Stubs/repository/interface.stub
@@ -2,13 +2,13 @@
 
 $NAMESPACE$
 
-use Prettus\Repository\Contracts\RepositoryInterface;
+$PARENT_CLASS$
 
 /**
  * Interface $CLASS$Repository
  * @package $NAMESPACE$
  */
-interface $CLASS$Repository extends RepositoryInterface
+interface $CLASS$Repository extends $PARENT_CLASS_NAME$
 {
     //
 }

--- a/src/Prettus/Repository/Generators/Stubs/transformer/transformer.stub
+++ b/src/Prettus/Repository/Generators/Stubs/transformer/transformer.stub
@@ -2,14 +2,14 @@
 
 $NAMESPACE$
 
-use League\Fractal\TransformerAbstract;
+$PARENT_CLASS$
 use $MODEL$;
 
 /**
  * Class $CLASS$Transformer
  * @package $NAMESPACE$
  */
-class $CLASS$Transformer extends TransformerAbstract
+class $CLASS$Transformer extends $PARENT_CLASS_NAME$
 {
 
     /**

--- a/src/Prettus/Repository/Generators/Stubs/validator/validator.stub
+++ b/src/Prettus/Repository/Generators/Stubs/validator/validator.stub
@@ -2,10 +2,10 @@
 
 $NAMESPACE$
 
+$PARENT_CLASS$
 use \Prettus\Validator\Contracts\ValidatorInterface;
-use \Prettus\Validator\LaravelValidator;
 
-class $CLASS$Validator extends LaravelValidator
+class $CLASS$Validator extends $PARENT_CLASS_NAME$
 {
 
     protected $rules = [

--- a/src/Prettus/Repository/Generators/TransformerGenerator.php
+++ b/src/Prettus/Repository/Generators/TransformerGenerator.php
@@ -82,9 +82,9 @@ class TransformerGenerator extends Generator
         ], '\\', $model);
 
         return array_merge(parent::getReplacements(), [
-            'model' => $model,
-            'parent_class'    => $this->getParentClass(),
-            'parent_class_name'    => $this->getParentClassName(),
+            'model'             => $model,
+            'parent_class'      => $this->getParentClass(),
+            'parent_class_name' => $this->getParentClassName(),
         ]);
     }
 }

--- a/src/Prettus/Repository/Generators/TransformerGenerator.php
+++ b/src/Prettus/Repository/Generators/TransformerGenerator.php
@@ -36,6 +36,16 @@ class TransformerGenerator extends Generator
     }
 
     /**
+     * Get parent class config node.
+     *
+     * @return string
+     */
+    public function getParentClassConfigNode()
+    {
+        return 'transformer';
+    }
+
+    /**
      * Get destination path for generated file.
      *
      * @return string
@@ -72,7 +82,9 @@ class TransformerGenerator extends Generator
         ], '\\', $model);
 
         return array_merge(parent::getReplacements(), [
-            'model' => $model
+            'model' => $model,
+            'parent_class'    => $this->getParentClass(),
+            'parent_class_name'    => $this->getParentClassName(),
         ]);
     }
 }

--- a/src/Prettus/Repository/Generators/ValidatorGenerator.php
+++ b/src/Prettus/Repository/Generators/ValidatorGenerator.php
@@ -39,6 +39,16 @@ class ValidatorGenerator extends Generator
     }
 
     /**
+     * Get parent class config node.
+     *
+     * @return string
+     */
+    public function getParentClassConfigNode()
+    {
+        return 'validator';
+    }
+
+    /**
      * Get destination path for generated file.
      *
      * @return string
@@ -68,6 +78,8 @@ class ValidatorGenerator extends Generator
 
         return array_merge(parent::getReplacements(), [
             'rules' => $this->getRules(),
+            'parent_class'    => $this->getParentClass(),
+            'parent_class_name'    => $this->getParentClassName(),
         ]);
     }
 

--- a/src/Prettus/Repository/Generators/ValidatorGenerator.php
+++ b/src/Prettus/Repository/Generators/ValidatorGenerator.php
@@ -77,9 +77,9 @@ class ValidatorGenerator extends Generator
     {
 
         return array_merge(parent::getReplacements(), [
-            'rules' => $this->getRules(),
-            'parent_class'    => $this->getParentClass(),
-            'parent_class_name'    => $this->getParentClassName(),
+            'rules'             => $this->getRules(),
+            'parent_class'      => $this->getParentClass(),
+            'parent_class_name' => $this->getParentClassName(),
         ]);
     }
 

--- a/src/resources/config/repository.php
+++ b/src/resources/config/repository.php
@@ -239,6 +239,15 @@ return [
             'controllers'  => 'Http/Controllers',
             'provider'     => 'RepositoryServiceProvider',
             'criteria'     => 'Criteria'
+        ],
+        'parentClasses'    => [
+            'model'        => \Illuminate\Database\Eloquent\Model::class,
+            'repository'   => \Prettus\Repository\Eloquent\BaseRepository::class,
+            'interface'    => \Prettus\Repository\Contracts\RepositoryInterface::class,
+            'transformer'  => \League\Fractal\TransformerAbstract::class,
+            'presenter'    => \Prettus\Repository\Presenter\FractalPresenter::class,
+            'validator'    => \Prettus\Validator\LaravelValidator::class,
+            'controller'   => \App\Http\Controllers\Controller::class,
         ]
     ]
 ];


### PR DESCRIPTION
Sometimes, for ease of development, we will define some methods in the base class.
Before, you need to manually modify the generated file.
Now, you only need to configure the base class.


**config/repository.php**
```
<?php
return [
    // ignore some code...

    'generator'  => [
        // ignore some code...

        'parentClasses'    => [
            'model'        => \Illuminate\Database\Eloquent\Model::class,
            'repository'   => \Prettus\Repository\Eloquent\BaseRepository::class,
            'interface'    => \Prettus\Repository\Contracts\RepositoryInterface::class,
            'transformer'  => \League\Fractal\TransformerAbstract::class,
            'presenter'    => \Prettus\Repository\Presenter\FractalPresenter::class,
            'validator'    => \Prettus\Validator\LaravelValidator::class,
            'controller'   => \App\Http\Controllers\Controller::class,
        ]

        // ignore some code...
    ]

    // ignore some code...
]
```

If you have a model base class, then you can configure it like this
**config/repository.php**
```
<?php
return [
    // ignore some code...

    'generator'  => [
        // ignore some code...

        'parentClasses'    => [
            'model'        => \App\BasicModel::class,
            'repository'   => \Prettus\Repository\Eloquent\BaseRepository::class,
            'interface'    => \Prettus\Repository\Contracts\RepositoryInterface::class,
            'transformer'  => \League\Fractal\TransformerAbstract::class,
            'presenter'    => \Prettus\Repository\Presenter\FractalPresenter::class,
            'validator'    => \Prettus\Validator\LaravelValidator::class,
            'controller'   => \App\Http\Controllers\Controller::class,
        ]

        // ignore some code...
    ]

    // ignore some code...
]
```


I think many people have such a demand.
Hope to be accepted, thanks.


Sorry. my English is not very good