### PR TITLE
Allow searching one field and multiple values

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,12 @@ or
 
 or
 
+Search one field by multiple values 
+
+`http://prettus.local/users?search=name:John Doe:Jane Doe`
+
+or
+
 `http://prettus.local/users?search=name:John;email:john@gmail.com&searchFields=name:like;email:=`
 
 ```json


### PR DESCRIPTION
This change allows searching one field by multiple values (potential solution for https://github.com/andersao/l5-repository/issues/73 and https://github.com/andersao/l5-repository/issues/364).
As shown bellow colon character can be used to delimit multiple values for searching one field.
`http://prettus.local/users?search=name:John Doe:Jane Doe`
So the query above will search for John and Jane Doe with OR condition in between: `name=John Doe OR name=Jane Doe`

Would this pattern work? I've decided to implement it like this since it was most natural way of doing it, based on current code (which was throwing away any additional search values).

I hope it doesn't brake any existing features; I've ran tests for queries bellow and I couldn't find any problems:
```
...?search=value1
...?search=fieldA:value1
...?searchJoin=or&search=fieldA:value1:value2
...?searchJoin=or&search=fieldA:value1&searchFields=fieldA:like
...?searchJoin=or&search=fieldA:value1:value2&searchFields=fieldA:like
...?searchJoin=or&search=fieldA:value1:value2;fieldB:value3&searchFields=fieldB:like;fieldA:=
...?searchJoin=and&search=fieldA:value1:value2;fieldB:value3&searchFields=fieldB:like;fieldA:=
...?searchJoin=and&search=fieldA:value1:value2;fieldB:value3&searchFields=fieldB:like;fieldA:like
...?searchJoin=or&search=fieldA:value1:value2;fieldB:value3&searchFields=fieldB:like;fieldA:like
```

If this pull request needs more work please let me know.

One idea of improving implementation was to always return $value-s as array from parserSearchData method (https://github.com/tad3j/l5-repository/blob/feature/feature/search_one_field_and_multiple_values/src/Prettus/Repository/Criteria/RequestCriteria.php#L229) and simplify query building code by always consuming an array.
