### PR TITLE
Fix paginate() declaration to match parent for PHP 7.2

### DIFF
--- a/src/Prettus/Repository/Traits/CacheableRepository.php
+++ b/src/Prettus/Repository/Traits/CacheableRepository.php
@@ -218,20 +218,21 @@ trait CacheableRepository
      *
      * @param null  $limit
      * @param array $columns
+     * @param string $method
      *
      * @return mixed
      */
-    public function paginate($limit = null, $columns = ['*'])
+    public function paginate($limit = null, $columns = ['*'], $method = 'paginate')
     {
         if (!$this->allowedCache('paginate') || $this->isSkippedCache()) {
-            return parent::paginate($limit, $columns);
+            return parent::paginate($limit, $columns, $method);
         }
 
         $key = $this->getCacheKey('paginate', func_get_args());
 
         $minutes = $this->getCacheMinutes();
-        $value = $this->getCacheRepository()->remember($key, $minutes, function () use ($limit, $columns) {
-            return parent::paginate($limit, $columns);
+        $value = $this->getCacheRepository()->remember($key, $minutes, function () use ($limit, $columns, $method) {
+            return parent::paginate($limit, $columns, $method);
         });
 
         $this->resetModel();


### PR DESCRIPTION
Issue: https://github.com/andersao/l5-repository/issues/483

Error:
```php
PHP Fatal error:  Declaration of Prettus\Repository\Traits\CacheableRepository::paginate($limit = NULL, $columns = Array) 
must be compatible with Prettus\Repository\Eloquent\BaseRepository::paginate($limit = NULL, $columns = Array, $method = 'paginate') 
in /path/to/project/app/Repositories/PirepRepository.php on line 10
```