### PR TITLE
fix-scopeQuery-update

### DIFF
--- a/src/Prettus/Repository/Eloquent/BaseRepository.php
+++ b/src/Prettus/Repository/Eloquent/BaseRepository.php
@@ -576,7 +576,11 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
             // we should pass data that has been casts by the model
             // to make sure data type are same because validator may need to use
             // this data to compare with data that fetch from database.
-            $attributes = $this->model->newInstance()->forceFill($attributes)->toArray();
+            if ($this->model instanceof Builder) {
+                $attributes = $this->model->getModel()->newInstance()->forceFill($attributes)->toArray();
+            } else {
+                $attributes = $this->model->newInstance()->forceFill($attributes)->toArray();
+            }
 
             $this->validator->with($attributes)->setId($id)->passesOrFail(ValidatorInterface::RULE_UPDATE);
         }


### PR DESCRIPTION
Some errors have been fixed while updating a limited range of data.
The following is an unexpected scene.
```php
$notification = $this->repository->scopeQuery(function ($builder) use ($user) {
    /* @var Builder $builder */
    return $builder->where('user_id', $user->id);
})->update([
    'is_read' => true,
], $id);
```