### PR TITLE
Fix Laravel 5.1 `addVisible` does not chain `$this`

### DIFF
--- a/src/Prettus/Repository/Eloquent/BaseRepository.php
+++ b/src/Prettus/Repository/Eloquent/BaseRepository.php
@@ -558,7 +558,9 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
             if( version_compare($this->app->version(), "5.2.*", ">") ){
                 $attributes = $this->model->newInstance()->forceFill($attributes)->makeVisible($this->model->getHidden())->toArray();
             }else{
-                $attributes = $this->model->newInstance()->forceFill($attributes)->addVisible($this->model->getHidden())->toArray();
+                $model = $this->model->newInstance()->forceFill($attributes);
+                $model->addVisible($this->model->getHidden());
+                $attributes = $model->toArray();
             }
 
             $this->validator->with($attributes)->passesOrFail(ValidatorInterface::RULE_CREATE);
@@ -594,7 +596,9 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
             if( version_compare($this->app->version(), "5.2.*", ">") ){
                 $attributes = $this->model->newInstance()->forceFill($attributes)->makeVisible($this->model->getHidden())->toArray();
             }else{
-                $attributes = $this->model->newInstance()->forceFill($attributes)->addVisible($this->model->getHidden())->toArray();
+                $model = $this->model->newInstance()->forceFill($attributes);
+                $model->addVisible($this->model->getHidden());
+                $attributes = $model->toArray();
             }
 
             $this->validator->with($attributes)->setId($id)->passesOrFail(ValidatorInterface::RULE_UPDATE);


### PR DESCRIPTION
2.6.30 introduced an issue for Laravel 5.1

`makeVisible` is not backwards compatible with `addVisible`, basically `makeVisible` returns the model to allow further chaining, `addVisible` does not. This PR fixes the attributes not being set correctly.