### PR TITLE
Bugfix: Eloquent validation not working in Lumen

### DIFF
--- a/src/Prettus/Repository/Eloquent/BaseRepository.php
+++ b/src/Prettus/Repository/Eloquent/BaseRepository.php
@@ -17,6 +17,7 @@ use Prettus\Repository\Events\RepositoryEntityCreated;
 use Prettus\Repository\Events\RepositoryEntityDeleted;
 use Prettus\Repository\Events\RepositoryEntityUpdated;
 use Prettus\Repository\Exceptions\RepositoryException;
+use Prettus\Repository\Traits\ComparesVersionsTrait;
 use Prettus\Validator\Contracts\ValidatorInterface;
 use Prettus\Validator\Exceptions\ValidatorException;
 
@@ -26,6 +27,7 @@ use Prettus\Validator\Exceptions\ValidatorException;
  */
 abstract class BaseRepository implements RepositoryInterface, RepositoryCriteriaInterface
 {
+    use ComparesVersionsTrait;
 
     /**
      * @var Application
@@ -555,7 +557,7 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
             // we should pass data that has been casts by the model
             // to make sure data type are same because validator may need to use
             // this data to compare with data that fetch from database.
-            if( version_compare($this->app->version(), "5.2.*", ">") ){
+            if( $this->versionCompare($this->app->version(), "5.2.*", ">") ){
                 $attributes = $this->model->newInstance()->forceFill($attributes)->makeVisible($this->model->getHidden())->toArray();
             }else{
                 $model = $this->model->newInstance()->forceFill($attributes);
@@ -593,7 +595,7 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
             // we should pass data that has been casts by the model
             // to make sure data type are same because validator may need to use
             // this data to compare with data that fetch from database.
-            if( version_compare($this->app->version(), "5.2.*", ">") ){
+            if( $this->versionCompare($this->app->version(), "5.2.*", ">") ){
                 $attributes = $this->model->newInstance()->forceFill($attributes)->makeVisible($this->model->getHidden())->toArray();
             }else{
                 $model = $this->model->newInstance()->forceFill($attributes);

--- a/src/Prettus/Repository/Traits/ComparesVersionsTrait.php
+++ b/src/Prettus/Repository/Traits/ComparesVersionsTrait.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: sune
+ * Date: 21/01/2018
+ * Time: 16.11
+ */
+
+namespace Prettus\Repository\Traits;
+
+trait ComparesVersionsTrait
+{
+    /**
+     * Version compare function that can compare both Laravel and Lumen versions.
+     *
+     * @param   string      $frameworkVersion
+     * @param   string      $compareVersion
+     * @param   string|null $operator
+     * @return  mixed
+     */
+    public function versionCompare($frameworkVersion, $compareVersion, $operator = null)
+    {
+        // Lumen (5.5.2) (Laravel Components 5.5.*)
+        $lumenPattern = '/Lumen \((\d\.\d\.[\d|\*])\)( \(Laravel Components (\d\.\d\.[\d|\*])\))?/';
+
+        if (preg_match($lumenPattern, $frameworkVersion, $matches)) {
+            $frameworkVersion = isset($matches[3]) ? $matches[3] : $matches[1]; // Prefer Laravel Components version.
+        }
+
+        return version_compare($frameworkVersion, $compareVersion, $operator);
+    }
+}


### PR DESCRIPTION
*Bugfix for Lumen*

The `BaseRepository` abstract class for Eloquent repositories uses a `version_compare` condition to either call `makeVisible` (newer versions) or `addVisible` (older versions), when performing validation for `create` and `update`.

Older versions calling `addVisible` will break validation by adding an empty `$visible` array on the model, effectively hiding all attributes, rather than showing them all, as intended by the code.

_I found this bug, since validation kept failing when it shouldn't. Traced it to `BaseRepository` where the the attributes are filled and then returned back, to apply casts, returned an empty array, instead of the casted attributes._

In Lumen, ` $app->version()` returns a funny string in the format `Lumen (5.5.2) (Laravel Components 5.5.*)`, where `version_compare` expects a PHP-style version, such as the one Laravel returns `5.5.0`.

This pull request uses a regex to check for the Lumen version format, and then parses the Laravel version from it, before running `version_compare`.