### PR TITLE
Add presenter on cache key.

### DIFF
--- a/src/Prettus/Repository/Traits/CacheableRepository.php
+++ b/src/Prettus/Repository/Traits/CacheableRepository.php
@@ -124,7 +124,7 @@ trait CacheableRepository
         $request = app('Illuminate\Http\Request');
         $args = serialize($args);
         $criteria = $this->serializeCriteria();
-        $key = sprintf('%s@%s-%s', get_called_class(), $method, md5($args . $criteria . $request->fullUrl()));
+        $key = sprintf('%s@%s-%s', get_called_class(), $method, md5($args . $criteria . serialize($this->presenter) . $request->fullUrl()));
 
         CacheKeys::putKey(get_called_class(), $key);
 


### PR DESCRIPTION
This will recognize result with presenter on managing cache repository.

```php
public function assignRoleToUser(Request $request)
{
    $user = $this->userRepository->find($userId); // this will return a user model

    $user->assignRole($role);// so we can execute this

    $this->userRepository->setPresenter(UserPresenter::class );
    return $this->userRepository->find($userId);//while this is return an array formatter by presenter
}           
```

Thanks :)