### PR TITLE
Compatibility to Laravel 5.8 cache scheme

### DIFF
--- a/src/Prettus/Repository/Traits/CacheableRepository.php
+++ b/src/Prettus/Repository/Traits/CacheableRepository.php
@@ -181,13 +181,14 @@ trait CacheableRepository
     /**
      * Get cache minutes
      *
-     * @return int
+     * @return Illuminate\Support\Carbon
      */
     public function getCacheMinutes()
     {
         $cacheMinutes = isset($this->cacheMinutes) ? $this->cacheMinutes : config('repository.cache.minutes', 30);
+        $cacheTimeStamp = now()->addMinutes($cacheMinutes);
 
-        return $cacheMinutes;
+        return $cacheTimeStamp;
     }
 
     /**


### PR DESCRIPTION
Changed the return value for getCacheMinutes() from int to Carbon to enable migration to 5.8 and backward compatibility.