### PR TITLE
Repository::find() instead Model::findOrFail() on update()

### DIFF
--- a/src/Prettus/Repository/Eloquent/BaseRepository.php
+++ b/src/Prettus/Repository/Eloquent/BaseRepository.php
@@ -611,7 +611,7 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
 
         $this->skipPresenter(true);
 
-        $model = $this->model->findOrFail($id);
+        $model = $this->find($id);
         $model->fill($attributes);
         $model->save();
 


### PR DESCRIPTION
In a project I need to overwrite the Repository::find() to use nanoid/hahsids, and missed the Repository::update() operation.

This change centralizes findOrFail operations only to Repository::find().