### PR TITLE
Add param type

### DIFF
--- a/src/Prettus/Repository/Eloquent/BaseRepository.php
+++ b/src/Prettus/Repository/Eloquent/BaseRepository.php
@@ -457,7 +457,7 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
     /**
      * Retrieve all data of repository, paginated
      *
-     * @param null $limit
+     * @param null|int $limit
      * @param array $columns
      * @param string $method
      *
@@ -478,7 +478,7 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
     /**
      * Retrieve all data of repository, simple paginated
      *
-     * @param null $limit
+     * @param null|int $limit
      * @param array $columns
      *
      * @return mixed


### PR DESCRIPTION
This matches the Eloquent Builder method param and fixes phpstan errors when using the parameter as expected.