### PR TITLE
Use classes instead of helper functions to support Laravel 6.0

### DIFF
--- a/src/Prettus/Repository/Criteria/RequestCriteria.php
+++ b/src/Prettus/Repository/Criteria/RequestCriteria.php
@@ -4,6 +4,7 @@ namespace Prettus\Repository\Criteria;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Prettus\Repository\Contracts\CriteriaInterface;
 use Prettus\Repository\Contracts\RepositoryInterface;
 
@@ -136,7 +137,7 @@ class RequestCriteria implements CriteriaInterface
                      * ex.
                      * products -> product_id
                      */
-                    $prefix = str_singular($sortTable);
+                    $prefix = Str::singular($sortTable);
                     $keyName = $table.'.'.$prefix.'_id';
                 }
 

--- a/src/Prettus/Repository/Generators/Commands/RepositoryCommand.php
+++ b/src/Prettus/Repository/Generators/Commands/RepositoryCommand.php
@@ -3,6 +3,7 @@ namespace Prettus\Repository\Generators\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use Prettus\Repository\Generators\FileAlreadyExistsException;
 use Prettus\Repository\Generators\MigrationGenerator;
 use Prettus\Repository\Generators\ModelGenerator;
@@ -66,7 +67,7 @@ class RepositoryCommand extends Command
         $this->generators = new Collection();
 
         $migrationGenerator = new MigrationGenerator([
-            'name'   => 'create_' . snake_case(str_plural($this->argument('name'))) . '_table',
+            'name'   => 'create_' . Str::snake(Str::plural($this->argument('name'))) . '_table',
             'fields' => $this->option('fillable'),
             'force'  => $this->option('force'),
         ]);

--- a/src/Prettus/Repository/Generators/ControllerGenerator.php
+++ b/src/Prettus/Repository/Generators/ControllerGenerator.php
@@ -1,6 +1,8 @@
 <?php
 namespace Prettus\Repository\Generators;
 
+use Illuminate\Support\Str;
+
 /**
  * Class ControllerGenerator
  * @package Prettus\Repository\Generators
@@ -75,7 +77,7 @@ class ControllerGenerator extends Generator
     public function getPluralName()
     {
 
-        return str_plural(lcfirst(ucwords($this->getClass())));
+        return Str::plural(lcfirst(ucwords($this->getClass())));
     }
 
     /**
@@ -103,7 +105,7 @@ class ControllerGenerator extends Generator
      */
     public function getSingularName()
     {
-        return str_singular(lcfirst(ucwords($this->getClass())));
+        return Str::singular(lcfirst(ucwords($this->getClass())));
     }
 
     /**

--- a/src/Prettus/Repository/Generators/Generator.php
+++ b/src/Prettus/Repository/Generators/Generator.php
@@ -135,10 +135,10 @@ abstract class Generator
     public function getName()
     {
         $name = $this->name;
-        if (str_contains($this->name, '\\')) {
+        if (Str::contains($this->name, '\\')) {
             $name = str_replace('\\', '/', $this->name);
         }
-        if (str_contains($this->name, '/')) {
+        if (Str::contains($this->name, '/')) {
             $name = str_replace('/', '/', $this->name);
         }
 

--- a/src/Prettus/Repository/Generators/Migrations/RulesParser.php
+++ b/src/Prettus/Repository/Generators/Migrations/RulesParser.php
@@ -2,6 +2,7 @@
 namespace Prettus\Repository\Generators\Migrations;
 
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Arr;
 
 /**
  * Class RulesParser
@@ -82,7 +83,7 @@ class RulesParser implements Arrayable
      */
     public function getColumn($rules)
     {
-        return array_first(explode('=>', $rules), function ($key, $value) {
+        return Arr::first(explode('=>', $rules), function ($key, $value) {
             return $value;
         });
     }

--- a/src/Prettus/Repository/Generators/Migrations/SchemaParser.php
+++ b/src/Prettus/Repository/Generators/Migrations/SchemaParser.php
@@ -2,6 +2,8 @@
 namespace Prettus\Repository\Generators\Migrations;
 
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 
 /**
  * Class SchemaParser
@@ -114,7 +116,7 @@ class SchemaParser implements Arrayable
      */
     public function getColumn($schema)
     {
-        return array_first(explode(':', $schema), function ($key, $value) {
+        return Arr::first(explode(':', $schema), function ($key, $value) {
             return $value;
         });
     }
@@ -208,7 +210,7 @@ class SchemaParser implements Arrayable
         if ($key == 0) {
             return '->' . $field . "('" . $column . "')";
         }
-        if (str_contains($field, '(')) {
+        if (Str::contains($field, '(')) {
             return '->' . $field;
         }
 


### PR DESCRIPTION
Have replaced all usages of helper functions str_* and array_* (excluding PHP builtins of course) with direct calls to support classes.

The helper functions have been direct passthroughs to the support classes all along so there should be no change to behaviour in any version of Laravel 5+ (helpers.php as at 5.0.1: https://github.com/laravel/framework/blob/022d46dc5eff9056e25078f283d2810749275966/src/Illuminate/Support/helpers.php)