### PR TITLE
Fixing configuration syntax error

### DIFF
--- a/src/resources/config/repository.php
+++ b/src/resources/config/repository.php
@@ -216,7 +216,7 @@ return [
             'orderBy'      => 'orderBy',
             'sortedBy'     => 'sortedBy',
             'with'         => 'with',
-            'searchJoin'   => 'searchJoin'
+            'searchJoin'   => 'searchJoin',
             'withCount'    => 'withCount'
         ]
     ],


### PR DESCRIPTION
there is missing comma on the config array