### PR TITLE
  ErrorException  : implode()

### DIFF
--- a/src/Prettus/Repository/Generators/Generator.php
+++ b/src/Prettus/Repository/Generators/Generator.php
@@ -259,7 +259,7 @@ abstract class Generator
             return null;
         }
 
-        return 'namespace ' . rtrim($rootNamespace . '\\' . implode($segments, '\\'), '\\') . ';';
+        return 'namespace ' . rtrim($rootNamespace . '\\' . implode('\\', $segments), '\\') . ';';
     }
 
 


### PR DESCRIPTION
Fix,  ErrorException  : implode(): Passing glue string after array is deprecated. Swap the parameters