### PR TITLE
Updated Generator to support PHP 7.4

### DIFF
--- a/src/Prettus/Repository/Generators/Generator.php
+++ b/src/Prettus/Repository/Generators/Generator.php
@@ -259,7 +259,7 @@ abstract class Generator
             return null;
         }
 
-        return 'namespace ' . rtrim($rootNamespace . '\\' . implode($segments, '\\'), '\\') . ';';
+        return 'namespace ' . rtrim($rootNamespace . '\\' . implode('\\', $segments), '\\') . ';';
     }
 
 


### PR DESCRIPTION
The implode function's usage changed in 7.4 which is now outlined as

implode ( string $glue , array $pieces ) : string