### PR TITLE
Laravel 7.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,13 @@
     "docs": "http://andersao.github.io/l5-repository"
   },
   "require": {
-    "illuminate/http": "~5.0|~6.0",
-    "illuminate/config": "~5.0|~6.0",
-    "illuminate/support": "~5.0|~6.0",
-    "illuminate/database": "~5.0|~6.0",
-    "illuminate/pagination": "~5.0|~6.0",
-    "illuminate/console": "~5.0|~6.0",
-    "illuminate/filesystem": "~5.0|~6.0",
+    "illuminate/http": "~5.0|~6.0|~7.0",
+    "illuminate/config": "~5.0|~6.0|~7.0",
+    "illuminate/support": "~5.0|~6.0|~7.0",
+    "illuminate/database": "~5.0|~6.0|~7.0",
+    "illuminate/pagination": "~5.0|~6.0|~7.0",
+    "illuminate/console": "~5.0|~6.0|~7.0",
+    "illuminate/filesystem": "~5.0|~6.0|~7.0",
     "prettus/laravel-validation": "~1.1|~1.2"
   },
   "autoload": {

--- a/src/Prettus/Repository/Eloquent/BaseRepository.php
+++ b/src/Prettus/Repository/Eloquent/BaseRepository.php
@@ -138,7 +138,6 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
      */
     public function validator()
     {
-
         if (isset($this->rules) && !is_null($this->rules) && is_array($this->rules) && !empty($this->rules)) {
             if (class_exists('Prettus\Validator\LaravelValidator')) {
                 $validator = app('Prettus\Validator\LaravelValidator');
@@ -348,7 +347,7 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
         $this->applyCriteria();
         $this->applyScope();
 
-        if($where) {
+        if ($where) {
             $this->applyConditions($where);
         }
 
@@ -436,7 +435,7 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
 
         return $this->parserResult($model);
     }
-    
+
     /**
      * Set the "limit" value of the query.
      *
@@ -622,7 +621,7 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
                 $attributes = $this->model->newInstance()->forceFill($attributes)->makeVisible($this->model->getHidden())->toArray();
             } else {
                 $model = $this->model->newInstance()->forceFill($attributes);
-                $model->addVisible($this->model->getHidden());
+                $model->makeVisible($this->model->getHidden());
                 $attributes = $model->toArray();
             }
 
@@ -660,7 +659,7 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
                 $attributes = $this->model->newInstance()->forceFill($attributes)->makeVisible($this->model->getHidden())->toArray();
             } else {
                 $model = $this->model->newInstance()->forceFill($attributes);
-                $model->addVisible($this->model->getHidden());
+                $model->makeVisible($this->model->getHidden());
                 $attributes = $model->toArray();
             }
 
@@ -989,7 +988,6 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
      */
     protected function applyCriteria()
     {
-
         if ($this->skipCriteria === true) {
             return $this;
         }


### PR DESCRIPTION
	• bump illuminate package dependency constraint to version ~7.0
	• the 'addVisible' method has been removed in laravel 7. The 'makeVisible' method should be used instead