### PR TITLE
 Fixing laravel 7.0 error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,13 @@
     "docs": "http://andersao.github.io/l5-repository"
   },
   "require": {
-    "illuminate/http": "~5.0|~6.0",
-    "illuminate/config": "~5.0|~6.0",
-    "illuminate/support": "~5.0|~6.0",
-    "illuminate/database": "~5.0|~6.0",
-    "illuminate/pagination": "~5.0|~6.0",
-    "illuminate/console": "~5.0|~6.0",
-    "illuminate/filesystem": "~5.0|~6.0",
+    "illuminate/http": "~5.0|~6.0|~7.0",
+    "illuminate/config": "~5.0|~6.0|~7.0",
+    "illuminate/support": "~5.0|~6.0|~7.0",
+    "illuminate/database": "~5.0|~6.0|~7.0",
+    "illuminate/pagination": "~5.0|~6.0|~7.0",
+    "illuminate/console": "~5.0|~6.0|~7.0",
+    "illuminate/filesystem": "~5.0|~6.0|~7.0",
     "prettus/laravel-validation": "~1.1|~1.2"
   },
   "autoload": {


### PR DESCRIPTION
Fixed errors:
 - don't install illuminate/filesystem 5.0.x-dev|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem 5.1.x-dev|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem 5.2.x-dev|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem 5.3.x-dev|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem 5.4.x-dev|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem 5.5.x-dev|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem 5.6.x-dev|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem 5.7.17|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem 5.7.18|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem 5.7.19|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem 5.7.x-dev|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem 5.8.x-dev|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.0.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.0.22|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.0.25|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.0.26|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.0.28|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.0.33|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.0.4|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.1.1|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.1.13|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.1.16|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.1.2|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.1.20|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.1.22|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.1.25|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.1.28|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.1.30|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.1.31|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.1.41|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.1.6|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.1.8|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.2.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.2.19|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.2.21|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.2.24|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.2.25|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.2.26|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.2.27|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.2.28|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.2.31|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.2.32|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.2.37|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.2.43|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.2.45|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.2.6|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.2.7|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.3.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.3.16|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.3.23|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.3.4|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.4.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.4.13|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.4.17|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.4.19|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.4.27|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.4.36|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.4.9|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.5.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.5.16|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.5.17|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.5.2|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.5.28|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.5.33|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.5.34|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.5.35|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.5.36|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.5.37|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.5.39|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.5.40|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.5.41|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.5.43|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.5.44|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.1|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.10|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.11|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.12|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.13|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.14|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.15|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.16|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.17|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.19|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.2|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.20|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.21|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.22|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.23|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.24|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.25|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.26|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.27|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.28|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.29|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.3|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.30|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.31|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.32|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.33|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.34|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.35|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.36|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.37|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.38|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.39|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.4|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.5|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.6|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.7|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.8|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.6.9|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.7.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.7.1|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.7.10|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.7.11|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.7.15|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.7.2|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.7.20|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.7.21|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.7.22|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.7.23|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.7.26|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.7.27|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.7.28|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.7.3|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.7.4|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.7.5|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.7.6|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.7.7|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.7.8|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.7.9|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.11|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.12|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.14|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.15|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.17|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.18|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.19|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.2|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.20|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.22|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.24|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.27|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.28|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.29|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.3|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.30|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.31|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.32|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.33|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.34|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.35|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.36|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.4|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.8|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v5.8.9|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem 6.x-dev|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.0.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.0.1|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.0.2|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.0.3|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.0.4|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.1.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.10.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.11.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.12.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.13.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.13.1|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.14.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.15.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.15.1|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.16.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.17.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.17.1|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.18.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.2.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.3.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.4.1|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.5.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.5.1|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.5.2|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.6.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.6.1|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.6.2|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.7.0|don't install laravel/framework v7.0.5
    - don't install illuminate/filesystem v6.8.0|don't install laravel/framework v7.0.5
    - Installation request for laravel/framework (locked at v7.0.5, required as ^7.0) -> satisfiable by laravel/framework[v7.0.5].
    - Installation request for prettus/l5-repository ^2.6 -> satisfiable by prettus/l5-repository[2.6.1, 2.6.10, 2.6.11, 2.6.12, 2.6.13, 2.6.14, 2.6.15, 2.6.16, 2.6.17, 2.6.18, 2.6.19, 2.6.2, 2.6.20, 2.6.21, 2.6.22, 2.6.23, 2.6.24, 2.6.25, 2.6.26, 2.6.27, 2.6.28, 2.6.29, 2.6.3, 2.6.30, 2.6.31, 2.6.32, 2.6.33, 2.6.34, 2.6.35, 2.6.36, 2.6.37, 2.6.38, 2.6.39, 2.6.4, 2.6.40, 2.6.41, 2.6.5, 2.6.6, 2.6.7, 2.6.8, 2.6.9].