### PR TITLE
Fix criteria cache exception for PHP 7.4 compatibility

### DIFF
--- a/src/Prettus/Repository/Traits/CacheableRepository.php
+++ b/src/Prettus/Repository/Traits/CacheableRepository.php
@@ -173,7 +173,6 @@ trait CacheableRepository
 
             return [
                 'hash' => md5((string) $r),
-                'properties' => $r->getProperties(),
             ];
         }
     }


### PR DESCRIPTION
Fixes #704 

I had a look at the cause of this error and I have removed the line causing the error after some investigation. 

As an example from my project the `$r->getProperties()` returns the following:

 ```php
array:3 [
  0 => ReflectionProperty {#3363
    +name: "request"
    +class: "App\Criteria\FieldsSearcheableCriteria"
    modifiers: "protected"
    extra: {
      docComment: """
        /**\n
             * @var \Illuminate\Http\Request\n
             */
        """
    }
  }
  1 => ReflectionProperty {#3259
    +name: "foo"
    +class: "App\Criteria\FieldsSearcheableCriteria"
    modifiers: "public"
  }
  2 => ReflectionProperty {#3348
    +name: "baz"
    +class: "App\Criteria\FieldsSearcheableCriteria"
    modifiers: "private"
  }
]
```

**Now if you look at the above it does not contain the property value. So I am not sure this is adding anything to the serialisation.** 

All I have done here is remove the line causing the error. In my opinion it is an unnecessary addition anyway the string version of the criteria class in the below returns all the information that is contained in the above array. 

```php
// Gets the contents of the class file as a string and hashes them
'hash' => md5((string) $r),
```

If you think that serialising the property values is required then that will be more involved as you will need come up with a new solution to get the properties and their values. Something similar to the below:

```php
$r = new ReflectionObject($criterion);

$criterionProperties = $r->getProperties();

$properties = collect($criterionProperties)->map(
    function (\ReflectionProperty $property) use ($criterion) {
        $property->setAccessible(true);
    
        $propertyValue = $property->getValue($criterion);
    
        if ($propertyValue instanceof Arrayable) {
            $propertyValue = $propertyValue->toArray();
        }
    
        return [(string) $property => $propertyValue];
    }
)->toArray();

return [
    'hash' => md5((string) $r),
    'properties' => $properties,
];
```

But you will potentially run into `Serialization of 'Closure' is not allowed` if any of the properties are objects with closures.

@jarektkaczyk Wrote this code some years ago but he might want to weigh in to see what he thinks. 