### PR TITLE
Returns the current instance of model

### DIFF
--- a/src/Prettus/Repository/Eloquent/BaseRepository.php
+++ b/src/Prettus/Repository/Eloquent/BaseRepository.php
@@ -109,6 +109,16 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
     }
 
     /**
+     * Returns the current Model instance
+     *
+     * @return Model
+     */
+    public function getModel()
+    {
+        return $this->model;
+    }
+
+    /**
      * @throws RepositoryException
      */
     public function resetModel()


### PR DESCRIPTION
# Use Case

Right now there is no way to inspect the current query of `$model` instance. sometimes it's useful that I can use repository function to apply queries but then want to handle results by myself. Or I want to debug what query has been prepared by the repository. Consider the following example,

I'm using the `whereHas` method to query the results of my `Post` table where the Author's name is like `mitul`. I got a relationship with `Post` model with a `User` model. so I'm doing a query like this.

```
$this->postRepository->whereHas('author', function ($builder) {
        $builder->where('name', 'like', '%mitul%');
});
$posts = $this->postRepository->all();
```

But for some reason, it's not working and I want to check what query has been prepared by using `toSql()` method. But as I can not directly access `$model` property of the repository, there is no way.

But adding `getModel()` public method to BaseRepository, I can call something like,

`dd($this->postRepository->getModel()->toSql());`

And it will give me output something like,

`select * from `posts` where exists (select * from `users` where `posts`.`author_id` = `users`.`id` and `name` like ?)`

This is a very basic case, but there can be other ideas as well where other people need this query for other purposes.

So adding this function can be a good addition.

Thank you.