### PR TITLE
Set optional validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
     "illuminate/pagination": "~5.0|~6.0|~7.0",
     "illuminate/console": "~5.0|~6.0|~7.0",
     "illuminate/filesystem": "~5.0|~6.0|~7.0",
-    "prettus/laravel-validation": "~1.1|~1.2",
     "illuminate/validation": "~5.0|~6.0|~7.0"
   },
   "autoload": {


### PR DESCRIPTION
To able to use this, they can run `composer require prettus/laravel-validation`