### PR TITLE
Implements `take` method()

### DIFF
--- a/src/Prettus/Repository/Eloquent/BaseRepository.php
+++ b/src/Prettus/Repository/Eloquent/BaseRepository.php
@@ -450,20 +450,19 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
     }
 
     /**
-     * Set the "limit" value of the query.
+     * Retrieve data of repository with limit applied
      *
-     * @param  int  $value
+     * @param int $limit
+     * @param array $columns
+     *
      * @return mixed
      */
-    public function limit($limit)
+    public function limit($limit, $columns = ['*'])
     {
-        $this->applyCriteria();
-        $this->applyScope();
-        $results = $this->model->limit($limit);
+        // Shortcut to all with `limit` applied on query via `take`
+        $this->take($limit);
 
-        $this->resetModel();
-
-        return $this->parserResult($results);
+        return $this->all($columns);
     }
 
     /**
@@ -863,9 +862,32 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
         return $this;
     }
 
+    /**
+     * Set the "orderBy" value of the query.
+     *
+     * @param mixed $column
+     * @param string $direction
+     *
+     * @return $this
+     */
     public function orderBy($column, $direction = 'asc')
     {
         $this->model = $this->model->orderBy($column, $direction);
+
+        return $this;
+    }
+
+    /**
+     * Set the "limit" value of the query.
+     *
+     * @param int $limit
+     *
+     * @return $this
+     */
+    public function take($limit)
+    {
+        // Internally `take` is an alias to `limit`
+        $this->model = $this->model->limit($limit);
 
         return $this;
     }


### PR DESCRIPTION
The current `limit` implementation introduced at #621 does it on the wrong manner, and totally different as expected from `orderBy` method(). 

To prevent BC I implemented Eloquent's `limit` as `take` (`take` is an alias to `limit`) and adjusted the `limit` description.

This PR also fixes #726 and #426