### PR TITLE
fill up search fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,6 +691,10 @@ or
 ]
 ```
 
+You can use params "search" without full params "searchFields".
+
+`http://prettus.local/users?search=id:2;age:17;email:john@gmail.com&searchFields='id':=`
+
 By default RequestCriteria makes its queries using the **OR** comparison operator for each query parameter.
 `http://prettus.local/users?search=age:17;email:john@gmail.com`
 

--- a/src/Prettus/Repository/Criteria/RequestCriteria.php
+++ b/src/Prettus/Repository/Criteria/RequestCriteria.php
@@ -50,23 +50,19 @@ class RequestCriteria implements CriteriaInterface
 
         if ($search && is_array($fieldsSearchable) && count($fieldsSearchable)) {
 
+            $fieldsSearchable = $this->fullFieldsSearchable($fieldsSearchable);
             $searchFields = is_array($searchFields) || is_null($searchFields) ? $searchFields : explode(';', $searchFields);
             $fields = $this->parserFieldsSearch($fieldsSearchable, $searchFields);
             $isFirstField = true;
             $searchData = $this->parserSearchData($search);
             $search = $this->parserSearchValue($search);
             $modelForceAndWhere = strtolower($searchJoin) === 'and';
+            $fields = $this->fullFieldsSearch($fieldsSearchable, $fields, $searchData, $search);
 
             $model = $model->where(function ($query) use ($fields, $search, $searchData, $isFirstField, $modelForceAndWhere) {
                 /** @var Builder $query */
 
                 foreach ($fields as $field => $condition) {
-
-                    if (is_numeric($field)) {
-                        $field = $condition;
-                        $condition = "=";
-                    }
-
                     $value = null;
 
                     $condition = trim(strtolower($condition));
@@ -311,10 +307,6 @@ class RequestCriteria implements CriteriaInterface
             }
 
             foreach ($originalFields as $field => $condition) {
-                if (is_numeric($field)) {
-                    $field = $condition;
-                    $condition = "=";
-                }
                 if (in_array($field, $searchFields)) {
                     $fields[$field] = $condition;
                 }
@@ -324,6 +316,60 @@ class RequestCriteria implements CriteriaInterface
                 throw new \Exception(trans('repository::criteria.fields_not_accepted', ['field' => implode(',', $searchFields)]));
             }
 
+        }
+
+        return $fields;
+    }
+
+    /**
+     * get fullFieldsSearch
+     * 
+     * case: searchFields = ['id' => '=', 'quantity' => '='], search = ['id' => 10, 'quantity' => 150, 'type' => 'order']
+     * In the above case, the request will not search for "type". My requirement is to search all "search params".
+     * Here is my workaround.
+     * 
+     * @param $fieldsSearchable
+     * @param $fields
+     * @param $searchData
+     * @param $search
+     * 
+     * @return array
+     */
+    protected function fullFieldsSearch(array $fieldsSearchable, array $fields = [], array $searchData = [], $search = null)
+    {
+        if (is_null($search)) {
+            $diff_keys = array_diff_key($searchData, $fields);
+
+            foreach ($diff_keys as $field => $value) {
+                if (array_key_exists($field, $fieldsSearchable)) {
+                    $fields[$field] = $fieldsSearchable[$field];
+                }
+            }
+        }
+
+        return $fields;
+    }
+
+    /**
+     * get fullFieldsSearchable
+     * 
+     * ex.
+     * ['id', 'quantity' => '='] -> ['id' => '=', 'quantity' => '=']
+     * 
+     * @param $fieldsSearchable
+     *
+     * @return array
+     */
+    protected function fullFieldsSearchable(array $fieldsSearchable)
+    {
+        $fields = [];
+
+        foreach ($fieldsSearchable as $field => $condition) {
+            if (is_numeric($field)) {
+                $field = $condition;
+                $condition = "=";
+            }
+            $fields[$field] = $condition;
         }
 
         return $fields;


### PR DESCRIPTION
case: searchFields = ['id' => '=', 'quantity' => '='], search = ['id' => 10, 'quantity' => 150, 'type' => 'order']
* In the above case, the request will not search for "type". My requirement is to search all "search params".
* Here is my workaround.

Review please @bsormagec @andersao. I need it for project of my company, thank you.

