### PR TITLE
set dynamic path of cache

### DIFF
--- a/src/Prettus/Repository/Helpers/CacheKeys.php
+++ b/src/Prettus/Repository/Helpers/CacheKeys.php
@@ -2,6 +2,8 @@
 
 namespace Prettus\Repository\Helpers;
 
+use Illuminate\Support\Facades\Config;
+
 /**
  * Class CacheKeys
  * @package Prettus\Repository\Helpers
@@ -65,7 +67,7 @@ class CacheKeys
      */
     public static function getFileKeys()
     {
-        $file = storage_path("framework/cache/" . self::$storeFile);
+        $file = storage_path(Config::get('cache.stores.file.path') . self::$storeFile);
 
         return $file;
     }


### PR DESCRIPTION
to maintain compatibility with systems such as aws lambda, where the storage path is originally just read-only, it would be interesting to keep the cache file location configurable

https://bref.sh/docs/frameworks/laravel.html#caching