### PR TITLE
fix cant generate fillable MigrationGenerator

### DIFF
--- a/src/Prettus/Repository/Generators/Migrations/SchemaParser.php
+++ b/src/Prettus/Repository/Generators/Migrations/SchemaParser.php
@@ -116,9 +116,7 @@ class SchemaParser implements Arrayable
      */
     public function getColumn($schema)
     {
-        return Arr::first(explode(':', $schema), function ($key, $value) {
-            return $value;
-        });
+        return Arr::first(explode(':', $schema));
     }
 
     /**


### PR DESCRIPTION
Fix for artisan command `make:repository` with flag --fillable, return wrong migratation format 