### PR TITLE
Fix strtolower() function deprecation issue #782

### DIFF
--- a/src/Prettus/Repository/Criteria/RequestCriteria.php
+++ b/src/Prettus/Repository/Criteria/RequestCriteria.php
@@ -45,7 +45,7 @@ class RequestCriteria implements CriteriaInterface
         $sortedBy = $this->request->get(config('repository.criteria.params.sortedBy', 'sortedBy'), 'asc');
         $with = $this->request->get(config('repository.criteria.params.with', 'with'), null);
         $withCount = $this->request->get(config('repository.criteria.params.withCount', 'withCount'), null);
-        $searchJoin = $this->request->get(config('repository.criteria.params.searchJoin', 'searchJoin'), null);
+        $searchJoin = $this->request->get(config('repository.criteria.params.searchJoin', 'searchJoin'), '');
         $sortedBy = !empty($sortedBy) ? $sortedBy : 'asc';
 
         if ($search && is_array($fieldsSearchable) && count($fieldsSearchable)) {


### PR DESCRIPTION
Fixing issue with the `strtolower()` function for PHP 8.1, where it is deprecated to receive `null` as a function parameter. Changed the default value of `$searchJoin` to empty string instead of `null`.