### PR TITLE
for prevent query exception ambiguous

### DIFF
--- a/src/Prettus/Repository/Criteria/RequestCriteria.php
+++ b/src/Prettus/Repository/Criteria/RequestCriteria.php
@@ -102,12 +102,13 @@ class RequestCriteria implements CriteriaInterface
                         if (!is_null($value)) {
                             if(!is_null($relation)) {
                                 $query->whereHas($relation, function($query) use($field,$condition,$value) {
+                                    $modelTableName = $query->getModel()->getTable();
                                     if($condition === 'in'){
-                                        $query->whereIn($field,$value);
+                                        $query->whereIn($$modelTableName.'.'.$field,$value);
                                     }elseif($condition === 'between'){
-                                        $query->whereBetween($field,$value);
+                                        $query->whereBetween($$modelTableName.'.'.$field,$value);
                                     }else{
-                                        $query->where($field,$condition,$value);
+                                        $query->where($$modelTableName.'.'.$field,$condition,$value);
                                     }
                                 });
                             } else {


### PR DESCRIPTION
i pass categories.id:10 in query params and get this error

```
Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous
```