### PR TITLE
Update php version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "docs": "http://andersao.github.io/l5-repository"
   },
   "require": {
-    "php": "^7.1",
+    "php": "^7.1|^8.0",
     "illuminate/http": "~5.0|~6.0|~7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
     "illuminate/config": "~5.0|~6.0|~7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
     "illuminate/support": "~5.0|~6.0|~7.0|^8.0|^9.0|^10.0|^11.0|^12.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c11f7921e8a31c261f3a359fc098fcec",
+    "content-hash": "016065060badd4e0f32e8143ad0d4431",
     "packages": [
         {
             "name": "brick/math",
@@ -3830,10 +3830,12 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform": {
+        "php": "^7.1|^8.0"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
After merging #825, support for PHP 8.x was dropped. 
This PR fixes that and restores compatibility with both PHP 7 and 8.