### PR TITLE
Fix deprecation error for null in strtolower() call

### DIFF
--- a/src/Prettus/Repository/Criteria/RequestCriteria.php
+++ b/src/Prettus/Repository/Criteria/RequestCriteria.php
@@ -55,7 +55,7 @@ class RequestCriteria implements CriteriaInterface
             $searchData = $this->parserSearchData($search);
             $fields = $this->parserFieldsSearch($fieldsSearchable, $searchFields, array_keys($searchData));
             $search = $this->parserSearchValue($search);
-            $modelForceAndWhere = strtolower($searchJoin) === 'and';
+            $modelForceAndWhere = strtolower($searchJoin ?? '') === 'and';
 
             $model = $model->where(function ($query) use ($fields, $search, $searchData, $isFirstField, $modelForceAndWhere) {
                 /** @var Builder $query */


### PR DESCRIPTION
This pull request makes a minor adjustment to the `apply` method in `RequestCriteria.php` to improve robustness when handling the `$searchJoin` variable.

* Improved null safety by using the null coalescing operator (`??`) when calling `strtolower` on `$searchJoin`, preventing potential errors if `$searchJoin` is null. (`src/Prettus/Repository/Criteria/RequestCriteria.php`)