### PR TITLE
Laravel 10-13 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "prettus/l5-repository",
-  "description": "Laravel 5|6|7|8|9|10|11|12 - Repositories to  the database layer",
+  "description": "Laravel 5|6|7|8|9|10|11|12|13 - Repositories to the database layer",
   "keywords": [
     "laravel",
     "repository",
@@ -26,16 +26,15 @@
     "docs": "http://andersao.github.io/l5-repository"
   },
   "require": {
-    "php": "^7.1|^8.0",
-    "illuminate/http": "~5.0|~6.0|~7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-    "illuminate/config": "~5.0|~6.0|~7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-    "illuminate/support": "~5.0|~6.0|~7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-    "illuminate/database": "~5.0|~6.0|~7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-    "illuminate/pagination": "~5.0|~6.0|~7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-    "illuminate/console": "~5.0|~6.0|~7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-    "illuminate/filesystem": "~5.0|~6.0|~7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-    "prettus/laravel-validation": "~1.1|~1.2|~1.3|~1.4|~1.5|~1.6|~1.7",
-    "illuminate/validation": "~5.0|~6.0|~7.0|^8.0|^9.0|^10.0|^11.0|^12.0"
+    "php": "^8.2",
+    "illuminate/http": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/config": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/pagination": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/filesystem": "^10.0|^11.0|^12.0|^13.0",
+    "illuminate/validation": "^10.0|^11.0|^12.0|^13.0"
   },
   "autoload": {
     "psr-4": {
@@ -48,7 +47,7 @@
   "suggest": {
     "league/fractal": "Required to use the Fractal Presenter (0.12.*).",
     "robclancy/presenter": "Required to use the Presenter Model (1.3.*)",
-    "prettus/laravel-validation": "Required to provide easy validation with the repository (1.1.*)"
+    "prettus/laravel-validation": "Required only if using Prettus validator integration."
   },
   "extra": {
     "laravel": {

--- a/src/Prettus/Repository/Eloquent/BaseRepository.php
+++ b/src/Prettus/Repository/Eloquent/BaseRepository.php
@@ -280,7 +280,8 @@ abstract class BaseRepository implements RepositoryInterface, RepositoryCriteria
     {
         $this->applyCriteria();
 
-        return $this->model->lists($column, $key);
+        // `lists()` was removed from Eloquent; `pluck()` is the modern equivalent.
+        return $this->model->pluck($column, $key);
     }
 
     /**


### PR DESCRIPTION
Update composer.json for PHP 8.2 and Laravel 10-13 compatibility; replace deprecated lists() method with pluck() in BaseRepository